### PR TITLE
[PBI-1252] Fix issue where preroll overlay was being time out by AMC

### DIFF
--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -402,6 +402,7 @@ OO.Ads.manager(function(_, $) {
           // Trigger the ad
           _registerDisplayForNonlinearAd();
           _registerDisplayForLinearAd();
+          debugger;
           currentPlayingSlot = ad.ad;
           indexInPod = 0;
           if (ad.isLinear) {
@@ -744,7 +745,7 @@ OO.Ads.manager(function(_, $) {
     var fw_onSlotStarted = function() {
       // adVideoElement may be null for overlays
       if (currentPlayingSlot &&
-          currentPlayingSlot.getTimePositionClass() === tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY &&
+          currentPlayingSlot.getTimePositionClass() !== tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY &&
           amc && amc.ui && amc.ui.adVideoElement) {
         amc.ui.adVideoElement.removeAttr('controls');
       }
@@ -766,16 +767,16 @@ OO.Ads.manager(function(_, $) {
     var fw_onSlotEnded = function(event) {
       // Disable controls on the video element.  Freewheel seems to be turning it on
       // TODO: inspect event for playback success or errors
+      
+      // adVideoElement may be null for overlays
+      if (currentPlayingSlot.getTimePositionClass() !== tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY &&
+          amc && amc.ui && amc.ui.adVideoElement) {
+        amc.ui.adVideoElement.attr('controls',false);
+      }
 
-      // check if ad is an overlay
       if (currentPlayingSlot &&
-          currentPlayingSlot.getTimePositionClass() === tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY) {
+          currentPlayingSlot.getTimePositionClass() == tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY) {
         _registerDisplayForLinearAd();
-
-        // adVideoElement may be null for overlays
-        if (amc && amc.ui && amc.ui.adVideoElement) {
-          amc.ui.adVideoElement.attr('controls',false);
-        }
       }
 
       if (!event || !event.slot) return;

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -769,7 +769,7 @@ OO.Ads.manager(function(_, $) {
 
       // check if ad is an overlay
       if (currentPlayingSlot &&
-          currentPlayingSlot.getTimePositionClass() == tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY) {
+          currentPlayingSlot.getTimePositionClass() === tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY) {
         _registerDisplayForLinearAd();
 
         // adVideoElement may be null for overlays

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -768,7 +768,8 @@ OO.Ads.manager(function(_, $) {
       // TODO: inspect event for playback success or errors
       
       // adVideoElement may be null for overlays
-      if (currentPlayingSlot.getTimePositionClass() !== tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY &&
+      if (currentPlayingSlot &&
+          currentPlayingSlot.getTimePositionClass() !== tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY &&
           amc && amc.ui && amc.ui.adVideoElement) {
         amc.ui.adVideoElement.attr('controls',false);
       }

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -52,7 +52,6 @@ OO.Ads.manager(function(_, $) {
     var adStartedCallbacks   = {};
     var adEndedCallbacks     = {};
     var indexInPod           = 0;
-    var currentAd            = null;
 
     // ui - do I need this?
     var freeWheelCompanionAdsWrapperId = null;
@@ -386,7 +385,6 @@ OO.Ads.manager(function(_, $) {
      */
     this.playAd = function(ad) {
       _resetAdState();
-      currentAd = ad;
       try {
         if (ad.ad.type == adRequestType) {
           if (shouldRequestAds) {
@@ -745,7 +743,9 @@ OO.Ads.manager(function(_, $) {
      */
     var fw_onSlotStarted = function() {
       // adVideoElement may be null for overlays
-      if (currentAd.isLinear && amc && amc.ui && amc.ui.adVideoElement) {
+      if (currentPlayingSlot &&
+          currentPlayingSlot.getTimePositionClass() === tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY &&
+          amc && amc.ui && amc.ui.adVideoElement) {
         amc.ui.adVideoElement.removeAttr('controls');
       }
 
@@ -766,15 +766,16 @@ OO.Ads.manager(function(_, $) {
     var fw_onSlotEnded = function(event) {
       // Disable controls on the video element.  Freewheel seems to be turning it on
       // TODO: inspect event for playback success or errors
-      
-      // adVideoElement may be null for overlays
-      if (currentAd.isLinear && amc && amc.ui && amc.ui.adVideoElement) {
-        amc.ui.adVideoElement.attr('controls',false);
-      }
 
+      // check if ad is an overlay
       if (currentPlayingSlot &&
           currentPlayingSlot.getTimePositionClass() == tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY) {
         _registerDisplayForLinearAd();
+
+        // adVideoElement may be null for overlays
+        if (amc && amc.ui && amc.ui.adVideoElement) {
+          amc.ui.adVideoElement.attr('controls',false);
+        }
       }
 
       if (!event || !event.slot) return;

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -402,7 +402,6 @@ OO.Ads.manager(function(_, $) {
           // Trigger the ad
           _registerDisplayForNonlinearAd();
           _registerDisplayForLinearAd();
-          debugger;
           currentPlayingSlot = ad.ad;
           indexInPod = 0;
           if (ad.isLinear) {

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -52,6 +52,7 @@ OO.Ads.manager(function(_, $) {
     var adStartedCallbacks   = {};
     var adEndedCallbacks     = {};
     var indexInPod           = 0;
+    var currentAd            = null;
 
     // ui - do I need this?
     var freeWheelCompanionAdsWrapperId = null;
@@ -385,6 +386,7 @@ OO.Ads.manager(function(_, $) {
      */
     this.playAd = function(ad) {
       _resetAdState();
+      currentAd = ad;
       try {
         if (ad.ad.type == adRequestType) {
           if (shouldRequestAds) {
@@ -743,7 +745,7 @@ OO.Ads.manager(function(_, $) {
      */
     var fw_onSlotStarted = function() {
       // adVideoElement may be null for overlays
-      if (amc && amc.ui && amc.ui.adVideoElement) {
+      if (currentAd.isLinear && amc && amc.ui && amc.ui.adVideoElement) {
         amc.ui.adVideoElement.removeAttr('controls');
       }
 
@@ -766,7 +768,7 @@ OO.Ads.manager(function(_, $) {
       // TODO: inspect event for playback success or errors
       
       // adVideoElement may be null for overlays
-      if (amc && amc.ui && amc.ui.adVideoElement) {
+      if (currentAd.isLinear && amc && amc.ui && amc.ui.adVideoElement) {
         amc.ui.adVideoElement.attr('controls',false);
       }
 

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -742,7 +742,10 @@ OO.Ads.manager(function(_, $) {
      * @method Freewheel#fw_onSlotStarted
      */
     var fw_onSlotStarted = function() {
-      amc.ui.adVideoElement.removeAttr('controls');
+      // adVideoElement may be null for overlays
+      if (amc && amc.ui && amc.ui.adVideoElement) {
+        amc.ui.adVideoElement.removeAttr('controls');
+      }
 
       // cancel timeout on load
       if (_.isFunction(slotStartedCallbacks[currentPlayingSlot.getCustomId()])) {
@@ -761,7 +764,11 @@ OO.Ads.manager(function(_, $) {
     var fw_onSlotEnded = function(event) {
       // Disable controls on the video element.  Freewheel seems to be turning it on
       // TODO: inspect event for playback success or errors
-      amc.ui.adVideoElement.attr('controls',false);
+      
+      // adVideoElement may be null for overlays
+      if (amc && amc.ui && amc.ui.adVideoElement) {
+        amc.ui.adVideoElement.attr('controls',false);
+      }
 
       if (currentPlayingSlot &&
           currentPlayingSlot.getTimePositionClass() == tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY) {


### PR DESCRIPTION
- Issue was caused by a TypeError in the fw_onSlotStarted function
- Similar issue found in fw_onSlotEnded function
- Add check to prevent TypeError in the event that adVideoElement is null or if the ad is non-linear