### PR TITLE
pbi-1283

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -557,7 +557,10 @@ require("../html5-common/js/utils/utils.js");
         //IMA provides values for getRemainingTime which can result in negative current times
         //or current times which are greater than duration.
         //We will check these boundaries so we will not report these unexpected current times
-        if (_IMAAdsManager && this.currentIMAAd && _IMAAdsManager.getRemainingTime() >= 0 && _IMAAdsManager.getRemainingTime() <= this.currentIMAAd.getDuration())
+        if (_IMAAdsManager &&
+          this.currentIMAAd &&
+          _IMAAdsManager.getRemainingTime() >= 0 &&
+          _IMAAdsManager.getRemainingTime() <= this.currentIMAAd.getDuration())
         {
           currentTime = this.currentIMAAd.getDuration() - _IMAAdsManager.getRemainingTime();
         }

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -90,7 +90,7 @@ require("../html5-common/js/utils/utils.js");
         _amc = amcIn;
 
         var ext = _amc.platform.DEV ? '_debug.js' : '.js';
-        remoteModuleJs = "//imasdk.googleapis.com/js/sdkloader/ima3" + ext;
+        var remoteModuleJs = "//imasdk.googleapis.com/js/sdkloader/ima3" + ext;
         _resetVars();
         _createAMCListeners();
         if (!this.runningUnitTests)
@@ -170,13 +170,16 @@ require("../html5-common/js/utils/utils.js");
        */
       var _removeAMCListeners = privateMember(function()
       {
-        _amc.removePlayerListener(_amc.EVENTS.INITIAL_PLAY_REQUESTED, _onInitialPlayRequested);
-        _amc.removePlayerListener(_amc.EVENTS.CONTENT_COMPLETED, _onContentCompleted);
-        _amc.removePlayerListener(_amc.EVENTS.PLAYHEAD_TIME_CHANGED, _onPlayheadTimeChanged);
-        _amc.removePlayerListener(_amc.EVENTS.SIZE_CHANGED, _onSizeChanged);
-        _amc.removePlayerListener(_amc.EVENTS.CONTENT_CHANGED, _onContentChanged);
-        _amc.removePlayerListener(_amc.EVENTS.REPLAY_REQUESTED, _onReplayRequested);
-        _amc.removePlayerListener(_amc.EVENTS.FULL_SCREEN_CHANGED, _onFullscreenChanged);
+        if (_amc)
+        {
+          _amc.removePlayerListener(_amc.EVENTS.INITIAL_PLAY_REQUESTED, _onInitialPlayRequested);
+          _amc.removePlayerListener(_amc.EVENTS.CONTENT_COMPLETED, _onContentCompleted);
+          _amc.removePlayerListener(_amc.EVENTS.PLAYHEAD_TIME_CHANGED, _onPlayheadTimeChanged);
+          _amc.removePlayerListener(_amc.EVENTS.SIZE_CHANGED, _onSizeChanged);
+          _amc.removePlayerListener(_amc.EVENTS.CONTENT_CHANGED, _onContentChanged);
+          _amc.removePlayerListener(_amc.EVENTS.REPLAY_REQUESTED, _onReplayRequested);
+          _amc.removePlayerListener(_amc.EVENTS.FULL_SCREEN_CHANGED, _onFullscreenChanged);
+        }
       });
 
       /**
@@ -1327,7 +1330,7 @@ require("../html5-common/js/utils/utils.js");
        */
       var _tryUndoSetupForAdRules = privateMember(function()
       {
-        if (_usingAdRules)
+        if (_usingAdRules && _amc)
         {
           _amc.adManagerDoneControllingAds(this.name);
         }

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -43,6 +43,7 @@ require("../html5-common/js/utils/utils.js");
       var _IMAAdsManagerInitialized;
       var _IMAAdDisplayContainer;
       var _linearAdIsPlaying;
+      var _timeUpdater = null;
 
       //Constants
       var DEFAULT_ADS_REQUEST_TIME_OUT = 3000;
@@ -57,6 +58,8 @@ require("../html5-common/js/utils/utils.js");
 
       var VISIBLE_CSS = {left: OO.CSS.VISIBLE_POSITION, visibility: "visible"};
       var INVISIBLE_CSS = {left: OO.CSS.INVISIBLE_POSITION, visibility: "hidden"};
+
+      var TIME_UPDATER_INTERVAL = 500;
 
       /**
        * Helper function to make functions private to GoogleIMA variable for consistency
@@ -548,11 +551,24 @@ require("../html5-common/js/utils/utils.js");
       this.getCurrentTime = function()
       {
         var currentTime = 0;
-        if (_IMAAdsManager && this.currentIMAAd)
+        //IMA provides values for getRemainingTime which can result in negative current times
+        //or current times which are greater than duration.
+        //We will check these boundaries so we will not report these unexpected current times
+        if (_IMAAdsManager && this.currentIMAAd && _IMAAdsManager.getRemainingTime() >= 0 && _IMAAdsManager.getRemainingTime() <= this.currentIMAAd.getDuration())
         {
           currentTime = this.currentIMAAd.getDuration() - _IMAAdsManager.getRemainingTime();
         }
         return currentTime;
+      };
+
+      this.getDuration = function()
+      {
+        var duration = 0;
+        if (this.currentIMAAd)
+        {
+          duration = this.currentIMAAd.getDuration();
+        }
+        return duration;
       };
 
       /**
@@ -1085,7 +1101,8 @@ require("../html5-common/js/utils/utils.js");
           eventType.THIRD_QUARTILE,
           eventType.VOLUME_CHANGED,
           eventType.VOLUME_MUTED,
-          eventType.USER_CLOSE];
+          eventType.USER_CLOSE,
+          eventType.DURATION_CHANGE];
 
         var addIMAEventListener =
           function(e)
@@ -1172,10 +1189,31 @@ require("../html5-common/js/utils/utils.js");
             this.currentIMAAd = ad;
             _onSizeChanged();
             _tryStartAd();
+            if (this.videoControllerWrapper)
+            {
+              this.videoControllerWrapper.raisePlayEvent();
+              this.videoControllerWrapper.raiseTimeUpdate(this.getCurrentTime(), this.getDuration());
+              _startTimeUpdater();
+            }
+            break;
+          case eventType.RESUMED:
+            if (this.videoControllerWrapper)
+            {
+              this.videoControllerWrapper.raisePlayEvent();
+            }
             break;
           case eventType.USER_CLOSE:
           case eventType.SKIPPED:
           case eventType.COMPLETE:
+            if (this.videoControllerWrapper)
+            {
+              _stopTimeUpdater();
+              //IMA provides values which can result in negative current times or current times which are greater than duration.
+              //For good user experience, we will provide the duration as the current time here if the event type is COMPLETE
+              var currentTime = adEvent.type === eventType.COMPLETE ? this.getDuration() : this.getCurrentTime();
+              this.videoControllerWrapper.raiseTimeUpdate(currentTime, this.getDuration());
+              this.videoControllerWrapper.raiseEndedEvent();
+            }
             //change this to end ad
             _endCurrentAd(false);
             _linearAdIsPlaying = false;
@@ -1189,6 +1227,12 @@ require("../html5-common/js/utils/utils.js");
               {
                 _IMA_SDK_resumeMainContent();
               }, this), 100);
+            }
+            break;
+          case eventType.PAUSED:
+            if (this.videoControllerWrapper)
+            {
+              this.videoControllerWrapper.raisePauseEvent();
             }
             break;
           case eventType.ALL_ADS_COMPLETED:
@@ -1212,35 +1256,55 @@ require("../html5-common/js/utils/utils.js");
           case eventType.THIRD_QUARTILE:
             _onAdMetrics(adEvent);
             break;
+          case eventType.VOLUME_CHANGED:
+          case eventType.VOLUME_MUTED:
+            if (this.videoControllerWrapper)
+            {
+              this.videoControllerWrapper.raiseVolumeEvent();
+            }
+            break;
+          case eventType.DURATION_CHANGE:
+            if (this.videoControllerWrapper)
+            {
+              this.videoControllerWrapper.raiseDurationChange(this.getCurrentTime(), this.getDuration());
+            }
+            break;
           default:
             break;
         }
+      });
 
-        if (this.videoControllerWrapper)
+      /**
+       * Starts a timer that will provide an update to the video controller wrapper of the ad's current time.
+       * We use a timer because IMA does not provide us with a time update event.
+       * @private
+       * @method GoogleIMA#_startTimeUpdater
+       */
+      var _startTimeUpdater = privateMember(function()
+      {
+        _stopTimeUpdater();
+        _timeUpdater = setInterval(_.bind(function()
         {
-          switch (adEvent.type)
+          if(_linearAdIsPlaying)
           {
-            case eventType.STARTED:
-            case eventType.RESUMED:
-              this.videoControllerWrapper.raisePlayEvent();
-              break;
-            case eventType.USER_CLOSE:
-            case eventType.SKIPPED:
-            case eventType.COMPLETE:
-              this.videoControllerWrapper.raiseEndedEvent();
-              break;
-            case eventType.PAUSED:
-              this.videoControllerWrapper.raisePauseEvent();
-              break;
-              break;
-            case eventType.VOLUME_CHANGED:
-            case eventType.VOLUME_MUTED:
-              this.videoControllerWrapper.raiseVolumeEvent();
-              break;
-            default:
-              break;
+            this.videoControllerWrapper.raiseTimeUpdate(this.getCurrentTime(), this.getDuration());
           }
-        }
+          else
+          {
+            _stopTimeUpdater();
+          }
+        }, this), TIME_UPDATER_INTERVAL);
+      });
+
+      /**
+       * Stops the timer that was started via _startTimeUpdater.
+       * @private
+       * @method GoogleIMA#_stopTimeUpdater
+       */
+      var _stopTimeUpdater = privateMember(function()
+      {
+        clearInterval(_timeUpdater);
+        _timeUpdater = null;
       });
 
       /**
@@ -1754,6 +1818,25 @@ require("../html5-common/js/utils/utils.js");
       var volume = _ima.getVolume();
       this.controller.notify(this.controller.EVENTS.VOLUME_CHANGE, { "volume" : volume });
     };
+
+    this.raiseTimeUpdate = function(currentTime, duration)
+    {
+      raisePlayhead(this.controller.EVENTS.TIME_UPDATE, currentTime, duration);
+    };
+
+    this.raiseDurationChange = function(currentTime, duration)
+    {
+      raisePlayhead(this.controller.EVENTS.DURATION_CHANGE, currentTime, duration);
+    };
+
+    var raisePlayhead = _.bind(function(eventname, currentTime, duration)
+    {
+      this.controller.notify(eventname,
+        { "currentTime" : currentTime,
+          "duration" : duration,
+          "buffer" : 0,
+          "seekRange" : { "begin" : 0, "end" : 0 } });
+    }, this);
   };
 
   OO.Video.plugin(new GoogleIMAVideoFactory());

--- a/test/unit-test-helpers/mock_amc.js
+++ b/test/unit-test-helpers/mock_amc.js
@@ -7,6 +7,9 @@ fake_amc = function() {
   this.EVENTS = {
     INITIAL_PLAY_REQUESTED : "initialPlayRequested"
   };
+  this.AD_SETTINGS  = {
+
+  };
   this.ADTYPE = {
     LINEAR_OVERLAY : "linearOverlay",
     NONLINEAR_OVERLAY : "nonlinearOverlay",
@@ -44,4 +47,8 @@ fake_amc = function() {
   this.notifyLinearAdEnded = function() {};
   this.notifyNonlinearAdStarted = function() {};
   this.notifyNonlinearAdEnded = function() {};
+
+  this.adManagerDoneControllingAds = function() {};
+  this.removePlayerListener = function() {};
+  this.adManagerSettings = {};
 };

--- a/test/unit-tests/freewheel_test.js
+++ b/test/unit-tests/freewheel_test.js
@@ -5,7 +5,6 @@
 
 //stubs
 OO.log = function() {};
-fake_amc = null;
 
 describe('ad_manager_freewheel', function() {
   var amc,fw;
@@ -120,7 +119,7 @@ describe('ad_manager_freewheel', function() {
   it('Init: fake ad is added to timeline', function(){
     initialize();
     expect(amc.timeline.length).to.be(1);
-    expect(amc.timeline[0].ad.type == "adRequest");
+    expect(amc.timeline[0].ad.type).to.be("adRequest");
   });
 
   it('Init: fw context is set up', function(){

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -1,0 +1,138 @@
+/*
+ * Unit test class for the Google IMA Ad Manager
+ * https://github.com/Automattic/expect.js
+ */
+
+//stubs
+OO.log = function() {};
+
+describe('ad_manager_ima', function() {
+  var amc,ima;
+  var imaVideoPluginFactory;
+  var name = "google-ima-ads-manager";
+  var playerId = "ima-player-id";
+  var originalOoAds = _.clone(OO.Ads);
+  //require(TEST_ROOT + "unit-test-helpers/mock_amc.js");
+
+  // IMA constants
+  var AD_RULES_POSITION_TYPE = 'r';
+  var NON_AD_RULES_POSITION_TYPE = 't';
+
+  // Helper functions
+
+  var initialize = function(adRules) {
+    ima.initialize(amc, playerId);
+    var ad = {
+      tag_url : "https://blah",
+      position_type : adRules ? AD_RULES_POSITION_TYPE : NON_AD_RULES_POSITION_TYPE
+    };
+    var content = {
+      all_ads : [ad]
+    };
+    ima.loadMetadata(content, {}, {});
+    amc.timeline = ima.buildTimeline();
+  };
+
+  var play = function() {
+    amc.callbacks[amc.EVENTS.INITIAL_PLAY_REQUESTED]();
+  };
+
+  before(_.bind(function() {
+    OO.Ads = {
+      manager: function(adManager){
+        ima = adManager(_, $);
+      }
+    };
+
+    OO.Video = {
+      plugin: function(plugin){
+        imaVideoPluginFactory = plugin;
+      }
+    };
+    amc = new fake_amc();
+    delete require.cache[require.resolve(SRC_ROOT + "google_ima.js")];
+    require(SRC_ROOT + "google_ima.js");
+  }, this));
+
+  after(function() {
+    OO.Ads = originalOoAds;
+  });
+
+  beforeEach(function() {
+  });
+
+  afterEach(_.bind(function() {
+    ima.destroy();
+  }, this));
+
+  //   ------   TESTS   ------
+
+  it('Init: mock amc is ready', function(){
+    expect(typeof amc).to.be("object");
+  });
+
+  it('Init: ad manager is registered', function(){
+    expect(typeof ima).to.be("object");
+  });
+
+  it('Init: ad manager has the expected name', function(){
+    expect(ima.name).to.be(name);
+  });
+
+  it('Init: ad manager handles the initialize function', function(){
+    expect(function() { ima.initialize(amc, playerId); }).to.not.throwException();
+  });
+
+  it('Init: video plugin is created after ad manager is initialized', function(){
+    ima.initialize(amc, playerId);
+    var imaVideoPlugin = imaVideoPluginFactory.create(null, null, null, null, playerId);
+    expect(typeof imaVideoPlugin).to.be("object");
+  });
+
+  it('Init: ad manager handles the registerUi function', function(){
+    expect(function() { ima.registerUi(); }).to.not.throwException();
+  });
+
+  it('Init: ad manager handles the loadMetadata function', function(){
+    var ad = {
+      tag_url : "https://blah",
+      position_type : AD_RULES_POSITION_TYPE
+    };
+    var content = {
+      all_ads : [ad]
+    };
+    ima.initialize(amc, playerId);
+    expect(function() { ima.loadMetadata(content, {}, {}); }).to.not.throwException();
+  });
+
+  it('Init: ad manager is ready', function(){
+    ima.initialize(amc, playerId);
+    expect(ima.ready).to.be(false);
+    var ad = {
+      tag_url : "https://blah",
+      position_type : AD_RULES_POSITION_TYPE
+    };
+    var content = {
+      all_ads : [ad]
+    };
+    ima.loadMetadata(content, {}, {});
+    expect(ima.ready).to.be(true);
+  });
+
+  it('Init: ad is added to timeline for non-ad-rules ads', function(){
+    debugger;
+    initialize(false);
+    expect(amc.timeline.length).to.be(1);
+    expect(amc.timeline[0].ad.type).not.to.be("adRequest");
+  });
+
+  it('Init: fake ad is added to timeline for ad rules ads', function(){
+    debugger;
+    initialize(true);
+    expect(amc.timeline.length).to.be(1);
+    expect(amc.timeline[0].ad.type).to.be("adRequest");
+  });
+
+  it('Timeline: adds all valid slots', function() {
+  });
+});

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -57,7 +57,7 @@ describe('ad_manager_vast', function() {
 
   var initalPlay = function() {
     amc.callbacks[amc.EVENTS.INITIAL_PLAY_REQUESTED]();
-  }
+  };
 
   before(_.bind(function() {
     OO.Ads = {


### PR DESCRIPTION
-ad marquee and scrubber will now properly reflect the current time for IMA ads
-moved videoControllerWrapper function calls into main event handler switch to better control the flow of events. This provides for a better user experience and less issues down the road. One example is previously we were going through the entire endCurrentAd flow (including publishing the relevant ad end messages) before we would notify the video controller that the ad was ending