### PR TITLE
[PBW-4017] Skip Ad button is not visible even after passing parameter.

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -282,12 +282,12 @@ OO.Ads.manager(function(_, $) {
         this.checkCompanionAds(adWrapper.ad);
         this.amc.showSkipVideoAdButton(true);
         var hasClickUrl = adWrapper.ad.data.linear.ClickThrough.length > 0;
+        var skippable = adWrapper.ad.data.linear.skippable;
         this.amc.notifyLinearAdStarted(this.name, {
             name: adWrapper.ad.data.title,
             duration: adWrapper.ad.durationInMilliseconds/1000,
             hasClickUrl: hasClickUrl,
-            indexInPod: 1,
-            skippable: false
+            indexInPod: 1
           });
       }
       else {


### PR DESCRIPTION
we were setting skippable : false in this.amc.notifyLinearAdStarted()
due to which we were unable to see the skip ad button. Setting this
based on the ad’s setting for skippable fixes the issue.