### PR TITLE
Pbi 1302

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-debug:
       --timeout 3500 \
       --require test/test_lib.js \
       --reporter $(REPORTER) \
-      --debug-brk --bail \
+      --debug --bail \
       $(UNIT_TESTS)
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-debug:
       --timeout 3500 \
       --require test/test_lib.js \
       --reporter $(REPORTER) \
-      --debug --bail \
+      --debug-brk --bail \
       $(UNIT_TESTS)
 
 .PHONY: test

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -935,11 +935,12 @@ require("../html5-common/js/utils/utils.js");
             _IMAAdDisplayContainer.destroy();
           }
 
-          var uiWrapper = this.sharedVideoElement ? _amc.ui.pluginsElement[0] : _amc.ui.adWrapper[0];
-
           //iphone performance is terrible if we don't use the custom playback (i.e. filling in the second param for adDisplayContainer)
           //also doesn't not seem to work nicely with podded ads if you don't use it.
-          _IMAAdDisplayContainer = new google.ima.AdDisplayContainer(uiWrapper,
+
+          //for IMA, we always want to use the plugins element to house the IMA UI. This allows it to behave
+          //properly with the Alice skin.
+          _IMAAdDisplayContainer = new google.ima.AdDisplayContainer(_amc.ui.pluginsElement[0],
                                                                      this.sharedVideoElement);
 
           _IMA_SDK_createAdsLoader();

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -935,9 +935,11 @@ require("../html5-common/js/utils/utils.js");
             _IMAAdDisplayContainer.destroy();
           }
 
+          var uiWrapper = this.sharedVideoElement ? _amc.ui.pluginsElement[0] : _amc.ui.adWrapper[0];
+
           //iphone performance is terrible if we don't use the custom playback (i.e. filling in the second param for adDisplayContainer)
           //also doesn't not seem to work nicely with podded ads if you don't use it.
-          _IMAAdDisplayContainer = new google.ima.AdDisplayContainer(_amc.ui.adWrapper[0],
+          _IMAAdDisplayContainer = new google.ima.AdDisplayContainer(uiWrapper,
                                                                      this.sharedVideoElement);
 
           _IMA_SDK_createAdsLoader();

--- a/test/unit-test-helpers/mock_ima.js
+++ b/test/unit-test-helpers/mock_ima.js
@@ -124,6 +124,10 @@ google =
               {        //convenience function for unit tests
                 return currentAd;
               };
+              this.isCustomPlaybackUsed = function()
+              {
+                return false;
+              };
             };
             google.ima.adManagerInstance = new mockAdManager();
           }


### PR DESCRIPTION
-single video element mode will now use plugins div rather than ad wrapper when creating an IMA AdDisplayContainer. This allows the IMA UI (Learn more and Skip button) to properly render on iPad
-added a mock function for unit tests so they work again