### PR TITLE
Pbi 741a

### DIFF
--- a/js/ad_manager_template.js
+++ b/js/ad_manager_template.js
@@ -130,6 +130,7 @@ OO.Ads.manager(function(_, $) {
      * @public
      * @param {object} ad The ad object to cancel
      * @param {object} params An object containing information about the cancellation
+     *                 code : The amc.AD_CANCEL_CODE for the cancellation
      */
     this.cancelAd = function(ad, params) {
     };

--- a/js/ad_manager_template.js
+++ b/js/ad_manager_template.js
@@ -129,7 +129,8 @@ OO.Ads.manager(function(_, $) {
      * @method AdManager#cancelAd
      * @public
      * @param {object} ad The ad object to cancel
-     * @param {object} params An object containing information about the cancellation
+     * @param {object} params An object containing information about the cancellation. It will include the
+     *                        following fields:
      *                 code : The amc.AD_CANCEL_CODE for the cancellation
      */
     this.cancelAd = function(ad, params) {

--- a/js/ad_manager_template.js
+++ b/js/ad_manager_template.js
@@ -216,8 +216,10 @@ OO.Ads.manager(function(_, $) {
      * this error itself, it can use this time to end the ad playback.
      * @method AdManager#adVideoError
      * @public
+     * @param {object} adWrapper The current Ad's metadata
+     * @param {number} errorCode The error code associated with the video playback error
      */
-    this.adVideoError = function() {
+    this.adVideoError = function(adWrapper, errorCode) {
     };
 
     /**

--- a/js/ad_manager_template.js
+++ b/js/ad_manager_template.js
@@ -198,6 +198,15 @@ OO.Ads.manager(function(_, $) {
     this.playerClicked = function(amcAd, showPage) {
     };
 
+    /**
+     * <i>Optional.</i><br/>
+     * Called when the player detects start of ad video playback.
+     * @method AdManager#adVideoPlaying
+     * @public
+     */
+    this.adVideoPlaying = function() {
+
+    };
 
     /**
      * <i>Optional.</i><br/>
@@ -222,7 +231,7 @@ OO.Ads.manager(function(_, $) {
     var _onContentChanged = function() {
       // Callback for example listener registered in this.initialize
     }
-  }
+  };
 
   return new AdManager();
 });

--- a/js/ad_manager_template.js
+++ b/js/ad_manager_template.js
@@ -129,8 +129,9 @@ OO.Ads.manager(function(_, $) {
      * @method AdManager#cancelAd
      * @public
      * @param {object} ad The ad object to cancel
+     * @param {object} params An object containing information about the cancellation
      */
-    this.cancelAd = function(ad) {
+    this.cancelAd = function(ad, params) {
     };
 
     /**

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -449,16 +449,21 @@ OO.Ads.manager(function(_, $) {
      * @public
      * @method Vast#cancelAd
      * @param {object} ad The Ad that needs to be cancelled
+     * @param {object} params An object containing information about the cancellation
      */
-    this.cancelAd = function(ad) {
+    this.cancelAd = function(ad, params) {
       //TODO: add timout logic if needed here as well.
       if (!this.amc || !this.amc.ui || !ad) {
         return;
       }
-      if (ad.isLinear) {
-        this.adVideoEnded();
+      if(params && params.code === this.amc.AD_CANCEL_CODE.TIMEOUT) {
+        failedAd();
       } else {
-        this.endAd(ad);
+        if (ad.isLinear) {
+          this.adVideoEnded();
+        } else {
+          this.endAd(ad);
+        }
       }
     };
 

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -1112,17 +1112,17 @@ OO.Ads.manager(function(_, $) {
       } else {
         var ad;
         //TODO: Determine when we show standalone ads if podded ads are available
-        //Show podded ads if available
-        if(!_.isEmpty(vastAds.podded)) {
-          handleAds(vastAds.podded, adLoaded);
-        }
-        //else show first standalone ad
-        else {
+        //If there are no podded ads
+        if(_.isEmpty(vastAds.podded)) {
+          //show the first standalone ad
           ad = vastAds.standalone[0];
+          if (ad) {
+            handleAds([ad], adLoaded);
+          }
         }
-
-        if (ad) {
-          handleAds([ad], adLoaded);
+        //else show the podded ads
+        else {
+          handleAds(vastAds.podded, adLoaded);
         }
       }
     };

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -91,9 +91,9 @@ OO.Ads.manager(function(_, $) {
      * @param {xml} vastXML Contains the vast ad data to be parsed.
      * @returns {boolean} Returns true if the xml is valid otherwise it returns false.
      */
-    this.isValidVastXML = _.bind(function(vastXML) {
+    this.isValidVastXML = function(vastXML) {
       return this.isValidRootTagName(vastXML);
-    }, this);
+    };
 
     /**
      * Helper function to verify XML has valid VAST root tag.
@@ -474,7 +474,10 @@ OO.Ads.manager(function(_, $) {
     this.endAd = function(ad) {
       if (ad) {
         if (ad.isLinear) {
-          var endOfPod = ad.ad.adPodIndex === ad.ad.adPodLength;
+          var endOfPod = false;
+          if (ad.ad.adPodIndex === ad.ad.adPodLength) {
+            endOfPod = true;
+          }
           // The VTC should pause the ad when the video element loses focus
           // Ask AMC to handle next ad only if not the end of pod. If end of pod,
           // notify pod ended will make this ask

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -385,8 +385,10 @@ OO.Ads.manager(function(_, $) {
      * ad is finished playing and we need to follow the process for cleaning up after an ad fails.
      * @public
      * @method Vast#adVideoError
+     * @param {object} adWrapper The current Ad's metadata
+     * @param {number} errorCode The error code associated with the VTC error
      */
-    this.adVideoError = function() {
+    this.adVideoError = function(adWrapper, errorCode) {
       // VTC will pause the ad when the video element loses focus
       failedAd();
     };

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -416,7 +416,7 @@ OO.Ads.manager(function(_, $) {
           }
         }
         adCompletedCallback = _.bind(function(ad, failed) {
-            this.endAd(ad, failed);
+            endAd(ad, failed);
             adCompletedCallback = null;
           }, this);
         this.checkCompanionAds(adWrapper.ad);
@@ -502,7 +502,7 @@ OO.Ads.manager(function(_, $) {
         if (ad.isLinear) {
           this.adVideoEnded();
         } else {
-          this.endAd(ad);
+          endAd(ad);
         }
       }
     };
@@ -510,12 +510,12 @@ OO.Ads.manager(function(_, $) {
     /**
      * Ends an ad. Notifies the AMC about the end of the ad. If it is the last linear ad in the pod,
      * will also notify the AMC of the end of the ad pod.
-     * @public
+     * @private
      * @method Vast#endAd
      * @param {object} ad The ad to end
      * @param {boolean} failed If true, the ending of this ad was caused by a failure
      */
-    this.endAd = function(ad, failed) {
+    var endAd = _.bind(function(ad, failed) {
       if (ad) {
         if (ad.isLinear) {
           this.amc.notifyLinearAdEnded(ad.id);
@@ -530,7 +530,7 @@ OO.Ads.manager(function(_, $) {
         }
       }
       currentAd = null;
-    };
+    }, this);
 
     /**
      * Called by the Ad Manager Controller when the module is unregistered, we need to remove any overlays that are visible.

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -777,7 +777,7 @@ OO.Ads.manager(function(_, $) {
      * @method Vast#_handleLinearAd
      * @param {object} ad The ad object
      * @param {object} adLoaded The ad that was loaded
-     * @param {object} params Additional params
+     * @param {object} params Additional parameters associated with this ad
      *                        adPodIndex : the index of the ad pod this ad is housed in
      *                        adPodLength : the total number of ads in the ad pod this ad is housed in
      * @returns {object} The ad unit object ready to be added to the timeline
@@ -825,7 +825,7 @@ OO.Ads.manager(function(_, $) {
      * @method Vast#_handleNonLinearAd
      * @param {object} ad The ad object
      * @param {object} adLoaded The ad that was loaded
-     * @param {object} params Additional params
+     * @param {object} params Additional parameters associated with this ad
      *                        adPodIndex : the index of the ad pod this ad is housed in
      *                        adPodLength : the total number of ads in the ad pod this ad is housed in
      * @returns {object} The ad unit object ready to be added to the timeline

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -463,6 +463,7 @@ OO.Ads.manager(function(_, $) {
       this.cancelAd();
       this.ready = false;
       this.currentDepth = 0;
+      this.inlineAd = null;
     };
 
     /**
@@ -972,7 +973,7 @@ OO.Ads.manager(function(_, $) {
       var linear = $(xml).find("Linear").eq(0);
       var nonLinearAds = $(xml).find("NonLinearAds");
 
-      if (result.type === "wrapper") { result.VASTAdTagURI = $(xml).find("VASTAdTagURI").text(); }
+      if (result.type === AD_TYPE.WRAPPER) { result.VASTAdTagURI = $(xml).find("VASTAdTagURI").text(); }
       result.error = filterEmpty($(xml).find("Error").map(function() { return $(this).text(); }));
       result.impression = filterEmpty($(xml).find("Impression").map(function() { return $(this).text(); }));
       result.title = _.first(filterEmpty($(xml).find("AdTitle").map(function() { return $(this).text(); })));
@@ -1076,6 +1077,8 @@ OO.Ads.manager(function(_, $) {
             this.trigger(this.ERROR, this);
             failedAd();
           }
+        } else if (ad.type === AD_TYPE.WRAPPER) {
+          //TODO: Wrapper ads
         }
       }, this));
     }, this);
@@ -1090,7 +1093,6 @@ OO.Ads.manager(function(_, $) {
      * @param {object} xml The xml returned from loading the ad
      */
     this._onVastResponse = function(adLoaded, xml) {
-      //TODO: vastAd should be vastAds. iterate over array of ads to keep old code
       var vastAds = this.parser(xml);
       if (!vastAds || !adLoaded || (_.isEmpty(vastAds.podded) && _.isEmpty(vastAds.standalone))) {
         this.errorType = "parseError";

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -416,7 +416,7 @@ OO.Ads.manager(function(_, $) {
           }
         }
         adCompletedCallback = _.bind(function(ad, failed) {
-            endAd(ad, failed);
+          _endAd(ad, failed);
             adCompletedCallback = null;
           }, this);
         this.checkCompanionAds(adWrapper.ad);
@@ -502,7 +502,7 @@ OO.Ads.manager(function(_, $) {
         if (ad.isLinear) {
           this.adVideoEnded();
         } else {
-          endAd(ad);
+          _endAd(ad);
         }
       }
     };
@@ -511,11 +511,11 @@ OO.Ads.manager(function(_, $) {
      * Ends an ad. Notifies the AMC about the end of the ad. If it is the last linear ad in the pod,
      * will also notify the AMC of the end of the ad pod.
      * @private
-     * @method Vast#endAd
+     * @method Vast#_endAd
      * @param {object} ad The ad to end
      * @param {boolean} failed If true, the ending of this ad was caused by a failure
      */
-    var endAd = _.bind(function(ad, failed) {
+    var _endAd = _.bind(function(ad, failed) {
       if (ad) {
         if (ad.isLinear) {
           this.amc.notifyLinearAdEnded(ad.id);
@@ -787,7 +787,7 @@ OO.Ads.manager(function(_, $) {
     var _handleLinearAd = _.bind(function(ad, adLoaded, params) {
       // filter our playable stream:
       if (_.isEmpty(ad.linear.mediaFiles)) {
-        return false;
+        return null;
       }
       params = params ? params : {};
       var mediaFiles = ad.linear.mediaFiles;
@@ -835,7 +835,7 @@ OO.Ads.manager(function(_, $) {
     var _handleNonLinearAd = _.bind(function(ad, adLoaded, params) {
       // filter our playable stream:
       if (_.isEmpty(ad.nonLinear.url)) {
-        return false;
+        return null;
       }
       params = params ? params : {};
       var adURL = ad.nonLinear.url;

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -349,15 +349,16 @@ OO.Ads.manager(function(_, $) {
     this.playAd = function(adWrapper) {
       // When the ad is done, trigger callback
       if (adWrapper.isLinear) {
-        this.amc.notifyPodStarted(adWrapper.id, adWrapper.ad.adPodLength);
-        adCompletedCallback = _.bind(function(amc, adId) {
-            amc.notifyLinearAdEnded(adId);
-            amc.notifyPodEnded(adId);
-          }, this, this.amc, adWrapper.id);
+        if (adWrapper.ad.adPodIndex === 1) {
+          this.amc.notifyPodStarted(adWrapper.id, adWrapper.ad.adPodLength);
+        }
+        adCompletedCallback = _.bind(function(ad) {
+            this.endAd(ad);
+          }, this, adWrapper);
         this.checkCompanionAds(adWrapper.ad);
         initSkipAdOffset(adWrapper);
         var hasClickUrl = adWrapper.ad.data.linear.ClickThrough.length > 0;
-        this.amc.notifyLinearAdStarted(this.name, {
+        this.amc.notifyLinearAdStarted(adWrapper.id, {
             name: adWrapper.ad.data.title,
             duration: adWrapper.ad.durationInMilliseconds/1000,
             hasClickUrl: hasClickUrl,
@@ -429,11 +430,21 @@ OO.Ads.manager(function(_, $) {
       if (!this.amc || !this.amc.ui) {
         return;
       }
+      this.endAd(ad);
+    };
+
+    /**
+     *
+     * @param ad
+     */
+    this.endAd = function(ad) {
       if (ad) {
         if (ad.isLinear) {
           // The VTC should pause the ad when the video element loses focus
-          this.amc.notifyLinearAdEnded(ad.id);
-          this.amc.notifyPodEnded(ad.id);
+          this.amc.notifyLinearAdEnded(ad.id, true);
+          if(ad.ad.adPodIndex === ad.ad.adPodLength) {
+            this.amc.notifyPodEnded(ad.id);
+          }
         } else {
           this.lastOverlayAd = null;
           this.amc.notifyNonlinearAdEnded(ad.id);

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -460,9 +460,9 @@ OO.Ads.manager(function(_, $) {
             slotEndedCallbacks[ad.ad.getCustomId()] = _.bind(function(adId) {
                 amc.notifyPodEnded(adId);
               }, this, ad.id);
-            adStartedCallbacks[ad.ad.getCustomId()] = _.bind(function(details) {
-                amc.notifyLinearAdStarted(this.name, details);
-              }, this);
+            adStartedCallbacks[ad.ad.getCustomId()] = _.bind(function(adId, details) {
+                amc.notifyLinearAdStarted(adId, details);
+              }, this, ad.id);
             adEndedCallbacks[ad.ad.getCustomId()] = _.bind(function(adId) {
                 amc.notifyLinearAdEnded(adId);
               }, this, ad.id);

--- a/test/unit-test-helpers/mock_amc.js
+++ b/test/unit-test-helpers/mock_amc.js
@@ -20,6 +20,12 @@ fake_amc = function() {
     LINEAR_VIDEO : "linearVideo",
     COMPANION : "companion"
   };
+  this.AD_CANCEL_CODE = {
+    SKIPPED : "skipped",
+    TIMEOUT : "timeout",
+    ERROR : "error",
+    STREAM_ENDED : "streamEnded"
+  };
   this.Ad = function(adObj){
     adObj.isLinear = (adObj.adType == "linearVideo") || (adObj.adType == "linearOverlay");
     return adObj

--- a/test/unit-test-helpers/mock_responses/vast_3_0_inline_podded.xml
+++ b/test/unit-test-helpers/mock_responses/vast_3_0_inline_podded.xml
@@ -1,50 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="3.0">
-    <Ad id="2281331" sequence="4">
-        <InLine>
-            <AdSystem version="4.6.0-5">LiveRail</AdSystem>
-            <AdTitle>TV Overlay PNG</AdTitle>
-            <Description>fake test</Description>
-            <Impression id="LR">impressionOverlayUrl</Impression>
-            <Impression id="QC">impressionOverlay2Url</Impression>
-            <Impression>impressionOverlay3Url</Impression>
-            <Impression>impressionOverlay4Url</Impression>
-            <Impression>impressionOverlay5Url</Impression>
-            <Impression>impressionOverlay6Url</Impression>
-            <Creatives>
-                <Creative sequence="1" id="8455">
-                    <NonLinearAds>
-                        <NonLinear width="300" height="60">
-                            <StaticResource creativeType="image/png">1.jpg</StaticResource>
-                            <NonLinearClickThrough>nonLinearClickThroughUrl</NonLinearClickThrough>                			            			</NonLinear>
-                        <TrackingEvents>
-                            <Tracking event="acceptInvitation">acceptInvitationUrl</Tracking>
-                            <Tracking event="collapse">collapseUrl</Tracking>
-                        </TrackingEvents>
-                    </NonLinearAds>
-                </Creative>
-                <Creative sequence="1" id="8455">
-                    <CompanionAds>
-                        <Companion width="300" height="60">
-                            <StaticResource creativeType="image/jpeg">companion.jpg</StaticResource>
-                            <TrackingEvents>
-                                <Tracking event="creativeView">companionCreativeViewUrl</Tracking>
-
-                            </TrackingEvents>
-                            <CompanionClickThrough>companionClickThroughUrl</CompanionClickThrough>
-                        </Companion>
-                        <Companion width="300" height="250">
-                            <StaticResource creativeType="image/jpeg">companion2.jpg</StaticResource>
-                            <TrackingEvents>
-                                <Tracking event="creativeView">companion2CreativeViewUrl</Tracking>
-
-                            </TrackingEvents>
-                            <CompanionClickThrough>companion2ClickThroughUrl</CompanionClickThrough>
-                        </Companion>
-                    </CompanionAds>
-                </Creative>
-            </Creatives>
-        </InLine>
-    </Ad>
     <Ad id="6654644" sequence="3">
         <InLine>
             <AdSystem>GDFP</AdSystem>
@@ -85,6 +39,15 @@
                             <MediaFile id="GDFP" delivery="progressive" bitrate="424" width="854" height="480" type="video/x-flv" scalable="false" maintainAspectRatio="false">3.flv</MediaFile>
                         </MediaFiles>
                     </Linear>
+                    <NonLinearAds>
+                        <NonLinear width="300" height="60">
+                            <StaticResource creativeType="image/png">1.jpg</StaticResource>
+                            <NonLinearClickThrough>nonLinearClickThroughUrl</NonLinearClickThrough>                			            			</NonLinear>
+                        <TrackingEvents>
+                            <Tracking event="acceptInvitation">acceptInvitationUrl</Tracking>
+                            <Tracking event="collapse">collapseUrl</Tracking>
+                        </TrackingEvents>
+                    </NonLinearAds>
                 </Creative>
                 <Creative sequence="1">
                     <CompanionAds>
@@ -190,6 +153,78 @@
         </InLine>
     </Ad>
     <Ad id="6654646" sequence="1">
+        <InLine>
+            <AdSystem>GDFP</AdSystem>
+            <AdTitle>video</AdTitle>
+            <Description>video ad</Description>
+            <Error>errorurl</Error>
+            <Impression>impressionurl</Impression>
+            <Creatives>
+                <Creative sequence="1">
+                    <Linear>
+                        <Duration>00:00:52</Duration>
+                        <TrackingEvents>
+                            <Tracking event="start">starturl</Tracking>
+                            <Tracking event="firstQuartile">firstQuartileurl</Tracking>
+                            <Tracking event="midpoint">midpointUrl</Tracking>
+                            <Tracking event="thirdQuartile">thirdQuartileUrl</Tracking>
+                            <Tracking event="complete">completeUrl</Tracking>
+                            <Tracking event="mute">muteUrl</Tracking>
+                            <Tracking event="unmute">unmuteUrl</Tracking>
+                            <Tracking event="rewind">rewindUrl</Tracking>
+                            <Tracking event="pause">pauseUrl</Tracking>
+                            <Tracking event="resume">resumeUrl</Tracking>
+                            <Tracking event="fullscreen">fullScreenUrl</Tracking>
+                            <Tracking event="acceptInvitation"></Tracking>
+                            <Tracking event="creativeView">creativeViewUrl</Tracking>
+                        </TrackingEvents>
+                        <VideoClicks>
+                            <ClickThrough id="GDFP">clickThroughUrl</ClickThrough>
+                        </VideoClicks>
+                        <MediaFiles>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="338" width="426" height="240" type="video/x-flv" scalable="false" maintainAspectRatio="false">1.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="330" width="640" height="360" type="video/mp4" scalable="false" maintainAspectRatio="false">1.mp4</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="84" width="176" height="144" type="video/3gpp" scalable="false" maintainAspectRatio="false">1.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="235" width="320" height="240" type="video/3gpp" scalable="false" maintainAspectRatio="false">2.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/x-flv" scalable="false" maintainAspectRatio="false">2.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/webm" scalable="false" maintainAspectRatio="false">1.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="538" width="854" height="480" type="video/webm" scalable="false" maintainAspectRatio="false">2.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="424" width="854" height="480" type="video/x-flv" scalable="false" maintainAspectRatio="false">3.flv</MediaFile>
+                        </MediaFiles>
+                    </Linear>
+                </Creative>
+                <Creative sequence="1">
+                    <CompanionAds>
+                        <Companion id="GDFP" width="728" height="90" >
+                            <StaticResource creativeType="image/jpeg">1.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companionCreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companionClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                        <Companion id="GDFP" width="300" height="250" >
+                            <StaticResource creativeType="image/jpeg">2.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companion2CreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companion2ClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                    </CompanionAds>
+                </Creative>
+            </Creatives>
+            <Extensions>
+                <Extension>
+                    <PreviousAdInformation>pK-gf_pnFp8KDQoLCLSVlgMQ7MS3ryY</PreviousAdInformation>
+                </Extension>
+                <Extension type="geo">
+                    <Bandwidth>4</Bandwidth>
+                </Extension>
+            </Extensions>
+        </InLine>
+    </Ad>
+    <Ad id="6654600">
         <InLine>
             <AdSystem>GDFP</AdSystem>
             <AdTitle>video</AdTitle>

--- a/test/unit-test-helpers/mock_responses/vast_3_0_inline_podded.xml
+++ b/test/unit-test-helpers/mock_responses/vast_3_0_inline_podded.xml
@@ -1,4 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="3.0">
+    <Ad id="2281331" sequence="4">
+        <InLine>
+            <AdSystem version="4.6.0-5">LiveRail</AdSystem>
+            <AdTitle>TV Overlay PNG</AdTitle>
+            <Description>fake test</Description>
+            <Impression id="LR">impressionOverlayUrl</Impression>
+            <Impression id="QC">impressionOverlay2Url</Impression>
+            <Impression>impressionOverlay3Url</Impression>
+            <Impression>impressionOverlay4Url</Impression>
+            <Impression>impressionOverlay5Url</Impression>
+            <Impression>impressionOverlay6Url</Impression>
+            <Creatives>
+                <Creative sequence="1" id="8455">
+                    <NonLinearAds>
+                        <NonLinear width="300" height="60">
+                            <StaticResource creativeType="image/png">1.jpg</StaticResource>
+                            <NonLinearClickThrough>nonLinearClickThroughUrl</NonLinearClickThrough>                			            			</NonLinear>
+                        <TrackingEvents>
+                            <Tracking event="acceptInvitation">acceptInvitationUrl</Tracking>
+                            <Tracking event="collapse">collapseUrl</Tracking>
+                        </TrackingEvents>
+                    </NonLinearAds>
+                </Creative>
+                <Creative sequence="1" id="8455">
+                    <CompanionAds>
+                        <Companion width="300" height="60">
+                            <StaticResource creativeType="image/jpeg">companion.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companionCreativeViewUrl</Tracking>
+
+                            </TrackingEvents>
+                            <CompanionClickThrough>companionClickThroughUrl</CompanionClickThrough>
+                        </Companion>
+                        <Companion width="300" height="250">
+                            <StaticResource creativeType="image/jpeg">companion2.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companion2CreativeViewUrl</Tracking>
+
+                            </TrackingEvents>
+                            <CompanionClickThrough>companion2ClickThroughUrl</CompanionClickThrough>
+                        </Companion>
+                    </CompanionAds>
+                </Creative>
+            </Creatives>
+        </InLine>
+    </Ad>
     <Ad id="6654644" sequence="3">
         <InLine>
             <AdSystem>GDFP</AdSystem>

--- a/test/unit-test-helpers/mock_responses/vast_3_0_inline_podded.xml
+++ b/test/unit-test-helpers/mock_responses/vast_3_0_inline_podded.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="3.0">
+    <Ad id="6654644" sequence="3">
+        <InLine>
+            <AdSystem>GDFP</AdSystem>
+            <AdTitle>video</AdTitle>
+            <Description>video ad</Description>
+            <Error>errorurl</Error>
+            <Impression>impressionurl</Impression>
+            <Creatives>
+                <Creative sequence="1">
+                    <Linear>
+                        <Duration>00:00:52</Duration>
+                        <TrackingEvents>
+                            <Tracking event="start">starturl</Tracking>
+                            <Tracking event="firstQuartile">firstQuartileurl</Tracking>
+                            <Tracking event="midpoint">midpointUrl</Tracking>
+                            <Tracking event="thirdQuartile">thirdQuartileUrl</Tracking>
+                            <Tracking event="complete">completeUrl</Tracking>
+                            <Tracking event="mute">muteUrl</Tracking>
+                            <Tracking event="unmute">unmuteUrl</Tracking>
+                            <Tracking event="rewind">rewindUrl</Tracking>
+                            <Tracking event="pause">pauseUrl</Tracking>
+                            <Tracking event="resume">resumeUrl</Tracking>
+                            <Tracking event="fullscreen">fullScreenUrl</Tracking>
+                            <Tracking event="acceptInvitation"></Tracking>
+                            <Tracking event="creativeView">creativeViewUrl</Tracking>
+                        </TrackingEvents>
+                        <VideoClicks>
+                            <ClickThrough id="GDFP">clickThroughUrl</ClickThrough>
+                        </VideoClicks>
+                        <MediaFiles>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="338" width="426" height="240" type="video/x-flv" scalable="false" maintainAspectRatio="false">1.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="330" width="640" height="360" type="video/mp4" scalable="false" maintainAspectRatio="false">1.mp4</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="84" width="176" height="144" type="video/3gpp" scalable="false" maintainAspectRatio="false">1.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="235" width="320" height="240" type="video/3gpp" scalable="false" maintainAspectRatio="false">2.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/x-flv" scalable="false" maintainAspectRatio="false">2.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/webm" scalable="false" maintainAspectRatio="false">1.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="538" width="854" height="480" type="video/webm" scalable="false" maintainAspectRatio="false">2.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="424" width="854" height="480" type="video/x-flv" scalable="false" maintainAspectRatio="false">3.flv</MediaFile>
+                        </MediaFiles>
+                    </Linear>
+                </Creative>
+                <Creative sequence="1">
+                    <CompanionAds>
+                        <Companion id="GDFP" width="728" height="90" >
+                            <StaticResource creativeType="image/jpeg">1.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companionCreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companionClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                        <Companion id="GDFP" width="300" height="250" >
+                            <StaticResource creativeType="image/jpeg">2.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companion2CreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companion2ClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                    </CompanionAds>
+                </Creative>
+            </Creatives>
+            <Extensions>
+                <Extension>
+                    <PreviousAdInformation>pK-gf_pnFp8KDQoLCLSVlgMQ7MS3ryY</PreviousAdInformation>
+                </Extension>
+                <Extension type="geo">
+                    <Bandwidth>4</Bandwidth>
+                </Extension>
+            </Extensions>
+        </InLine>
+    </Ad>
+    <Ad id="6654645" sequence="2">
+        <InLine>
+            <AdSystem>GDFP</AdSystem>
+            <AdTitle>video</AdTitle>
+            <Description>video ad</Description>
+            <Error>errorurl</Error>
+            <Impression>impressionurl</Impression>
+            <Creatives>
+                <Creative sequence="1">
+                    <Linear>
+                        <Duration>00:00:52</Duration>
+                        <TrackingEvents>
+                            <Tracking event="start">starturl</Tracking>
+                            <Tracking event="firstQuartile">firstQuartileurl</Tracking>
+                            <Tracking event="midpoint">midpointUrl</Tracking>
+                            <Tracking event="thirdQuartile">thirdQuartileUrl</Tracking>
+                            <Tracking event="complete">completeUrl</Tracking>
+                            <Tracking event="mute">muteUrl</Tracking>
+                            <Tracking event="unmute">unmuteUrl</Tracking>
+                            <Tracking event="rewind">rewindUrl</Tracking>
+                            <Tracking event="pause">pauseUrl</Tracking>
+                            <Tracking event="resume">resumeUrl</Tracking>
+                            <Tracking event="fullscreen">fullScreenUrl</Tracking>
+                            <Tracking event="acceptInvitation"></Tracking>
+                            <Tracking event="creativeView">creativeViewUrl</Tracking>
+                        </TrackingEvents>
+                        <VideoClicks>
+                            <ClickThrough id="GDFP">clickThroughUrl</ClickThrough>
+                        </VideoClicks>
+                        <MediaFiles>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="338" width="426" height="240" type="video/x-flv" scalable="false" maintainAspectRatio="false">1.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="330" width="640" height="360" type="video/mp4" scalable="false" maintainAspectRatio="false">1.mp4</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="84" width="176" height="144" type="video/3gpp" scalable="false" maintainAspectRatio="false">1.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="235" width="320" height="240" type="video/3gpp" scalable="false" maintainAspectRatio="false">2.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/x-flv" scalable="false" maintainAspectRatio="false">2.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/webm" scalable="false" maintainAspectRatio="false">1.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="538" width="854" height="480" type="video/webm" scalable="false" maintainAspectRatio="false">2.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="424" width="854" height="480" type="video/x-flv" scalable="false" maintainAspectRatio="false">3.flv</MediaFile>
+                        </MediaFiles>
+                    </Linear>
+                </Creative>
+                <Creative sequence="1">
+                    <CompanionAds>
+                        <Companion id="GDFP" width="728" height="90" >
+                            <StaticResource creativeType="image/jpeg">1.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companionCreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companionClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                        <Companion id="GDFP" width="300" height="250" >
+                            <StaticResource creativeType="image/jpeg">2.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companion2CreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companion2ClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                    </CompanionAds>
+                </Creative>
+            </Creatives>
+            <Extensions>
+                <Extension>
+                    <PreviousAdInformation>pK-gf_pnFp8KDQoLCLSVlgMQ7MS3ryY</PreviousAdInformation>
+                </Extension>
+                <Extension type="geo">
+                    <Bandwidth>4</Bandwidth>
+                </Extension>
+            </Extensions>
+        </InLine>
+    </Ad>
+    <Ad id="6654646" sequence="1">
+        <InLine>
+            <AdSystem>GDFP</AdSystem>
+            <AdTitle>video</AdTitle>
+            <Description>video ad</Description>
+            <Error>errorurl</Error>
+            <Impression>impressionurl</Impression>
+            <Creatives>
+                <Creative sequence="1">
+                    <Linear>
+                        <Duration>00:00:52</Duration>
+                        <TrackingEvents>
+                            <Tracking event="start">starturl</Tracking>
+                            <Tracking event="firstQuartile">firstQuartileurl</Tracking>
+                            <Tracking event="midpoint">midpointUrl</Tracking>
+                            <Tracking event="thirdQuartile">thirdQuartileUrl</Tracking>
+                            <Tracking event="complete">completeUrl</Tracking>
+                            <Tracking event="mute">muteUrl</Tracking>
+                            <Tracking event="unmute">unmuteUrl</Tracking>
+                            <Tracking event="rewind">rewindUrl</Tracking>
+                            <Tracking event="pause">pauseUrl</Tracking>
+                            <Tracking event="resume">resumeUrl</Tracking>
+                            <Tracking event="fullscreen">fullScreenUrl</Tracking>
+                            <Tracking event="acceptInvitation"></Tracking>
+                            <Tracking event="creativeView">creativeViewUrl</Tracking>
+                        </TrackingEvents>
+                        <VideoClicks>
+                            <ClickThrough id="GDFP">clickThroughUrl</ClickThrough>
+                        </VideoClicks>
+                        <MediaFiles>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="338" width="426" height="240" type="video/x-flv" scalable="false" maintainAspectRatio="false">1.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="330" width="640" height="360" type="video/mp4" scalable="false" maintainAspectRatio="false">1.mp4</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="84" width="176" height="144" type="video/3gpp" scalable="false" maintainAspectRatio="false">1.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="235" width="320" height="240" type="video/3gpp" scalable="false" maintainAspectRatio="false">2.3gp</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/x-flv" scalable="false" maintainAspectRatio="false">2.flv</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/webm" scalable="false" maintainAspectRatio="false">1.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="538" width="854" height="480" type="video/webm" scalable="false" maintainAspectRatio="false">2.webm</MediaFile>
+                            <MediaFile id="GDFP" delivery="progressive" bitrate="424" width="854" height="480" type="video/x-flv" scalable="false" maintainAspectRatio="false">3.flv</MediaFile>
+                        </MediaFiles>
+                    </Linear>
+                </Creative>
+                <Creative sequence="1">
+                    <CompanionAds>
+                        <Companion id="GDFP" width="728" height="90" >
+                            <StaticResource creativeType="image/jpeg">1.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companionCreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companionClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                        <Companion id="GDFP" width="300" height="250" >
+                            <StaticResource creativeType="image/jpeg">2.jpg</StaticResource>
+                            <TrackingEvents>
+                                <Tracking event="creativeView">companion2CreativeViewUrl</Tracking>
+                            </TrackingEvents>
+                            <CompanionClickThrough>companion2ClickThrough</CompanionClickThrough>
+
+                        </Companion>
+                    </CompanionAds>
+                </Creative>
+            </Creatives>
+            <Extensions>
+                <Extension>
+                    <PreviousAdInformation>pK-gf_pnFp8KDQoLCLSVlgMQ7MS3ryY</PreviousAdInformation>
+                </Extension>
+                <Extension type="geo">
+                    <Bandwidth>4</Bandwidth>
+                </Extension>
+            </Extensions>
+        </InLine>
+    </Ad>
+</VAST>

--- a/test/unit-test-helpers/mock_responses/vast_linear.xml
+++ b/test/unit-test-helpers/mock_responses/vast_linear.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="2.0"><Ad id="6654644">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="2.0">
+<Ad id="6654644">
 <InLine>
 <AdSystem>GDFP</AdSystem>
 <AdTitle>video</AdTitle>

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -723,4 +723,103 @@ describe('ad_manager_vast', function() {
     expect(adPodLength).to.be(3);
     expect(indexInPod).to.be(3);
   });
+
+  it('Vast 3.0: AMC is notified of linear/nonlinear ad start/end and pod start/end', function(){
+    var nonLinearStartNotified = 0;
+    var podStartNotified = 0;
+    var podEndNotified = 0;
+    var linearStartNotified = 0;
+    var linearEndNotified = 0;
+
+    amc.notifyPodStarted = function() {
+      podStartNotified++;
+    };
+    amc.notifyPodEnded = function() {
+      podEndNotified++;
+    };
+    amc.notifyLinearAdStarted = function() {
+      linearStartNotified++;
+    };
+    amc.notifyLinearAdEnded = function() {
+      linearEndNotified++;
+    };
+    amc.sendURLToLoadAndPlayNonLinearAd = function() {
+      nonLinearStartNotified++;
+    };
+    var embed_code = "embed_code";
+    var vast_ad_mid = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:10,
+      position_type:"t",
+      url:"1.mp4"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad_mid]
+    };
+    vastAdManager.initialize(amc);
+    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
+    initalPlay();
+    expect(vastAdManager.initialPlay()).to.be(true);
+    //TODO: expand on these tests
+    vastAdManager._onVastResponse(vast_ad_mid, linear3_0XMLPodded);
+
+    var vastAd = amc.timeline[0];
+    vastAdManager.playAd(vastAd);
+    expect(podStartNotified).to.be(1);
+    expect(podEndNotified).to.be(0);
+    expect(linearStartNotified).to.be(1);
+    expect(linearEndNotified).to.be(0);
+    expect(nonLinearStartNotified).to.be(0);
+
+    vastAdManager.adVideoEnded();
+    expect(podStartNotified).to.be(1);
+    expect(podEndNotified).to.be(0);
+    expect(linearStartNotified).to.be(1);
+    expect(linearEndNotified).to.be(1);
+    expect(nonLinearStartNotified).to.be(0);
+
+    vastAd = amc.timeline[1];
+    vastAdManager.playAd(vastAd);
+    expect(podStartNotified).to.be(1);
+    expect(podEndNotified).to.be(0);
+    expect(linearStartNotified).to.be(2);
+    expect(linearEndNotified).to.be(1);
+    expect(nonLinearStartNotified).to.be(0);
+
+    vastAdManager.adVideoEnded();
+    expect(podStartNotified).to.be(1);
+    expect(podEndNotified).to.be(0);
+    expect(linearStartNotified).to.be(2);
+    expect(linearEndNotified).to.be(2);
+    expect(nonLinearStartNotified).to.be(0);
+
+    vastAd = amc.timeline[2];
+    vastAdManager.playAd(vastAd);
+    expect(podStartNotified).to.be(1);
+    expect(podEndNotified).to.be(0);
+    expect(linearStartNotified).to.be(3);
+    expect(linearEndNotified).to.be(2);
+    expect(nonLinearStartNotified).to.be(0);
+
+    vastAdManager.adVideoEnded();
+    expect(podStartNotified).to.be(1);
+    expect(podEndNotified).to.be(1);
+    expect(linearStartNotified).to.be(3);
+    expect(linearEndNotified).to.be(3);
+    expect(nonLinearStartNotified).to.be(0);
+
+    //overlay
+    vastAd = amc.timeline[3];
+    vastAdManager.playAd(vastAd);
+    expect(podStartNotified).to.be(1);
+    expect(podEndNotified).to.be(1);
+    expect(linearStartNotified).to.be(3);
+    expect(linearEndNotified).to.be(3);
+    expect(nonLinearStartNotified).to.be(1);
+  });
 });

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -471,6 +471,7 @@ describe('ad_manager_vast', function() {
     expect(vastAd.ad.data.companion[1].tracking.creativeView).to.eql(['companion2CreativeViewUrl']);
   });
 
+  //TODO: Fix wrapper ads test
   //it('should parse wrapper ads', function(){
   //  var embed_code = "embed_code";
   //  var vast_ad_mid = {

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -632,6 +632,19 @@ describe('ad_manager_vast', function() {
   });
 
   it('Vast 3.0: should parse inline linear podded ads', function(){
+    var adQueue = [];
+    amc.forceAdToPlay = function(adManager, ad, adType, streams) {
+      var adData = {
+        "adManager": adManager,
+        "adType": adType,
+        "ad": ad,
+        "streams":streams,
+        "position": -1 //we want it to play immediately
+      };
+      var newAd = new amc.Ad(adData);
+      adQueue.push(newAd);
+    };
+
     var embed_code = "embed_code";
     var vast_ad_mid = {
       type: "vast",
@@ -663,7 +676,7 @@ describe('ad_manager_vast', function() {
 
     vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
-    vastAd = amc.timeline[1];
+    vastAd = adQueue[0];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
@@ -673,12 +686,13 @@ describe('ad_manager_vast', function() {
 
     vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
-    vastAd = amc.timeline[2];
+    vastAd = adQueue[1];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
     expect(vastAd.ad.data.linear).not.to.be(null);
     expect(vastAd.ad.data.id).to.be('6654644');
+    vastAdManager.playAd(vastAd);
 
     vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
@@ -687,6 +701,20 @@ describe('ad_manager_vast', function() {
   it('Vast 3.0: should provide proper ad pod positions and length to AMC on playAd', function(){
     var adPodLength = -1;
     var indexInPod = -1;
+    var adQueue = [];
+
+    amc.forceAdToPlay = function(adManager, ad, adType, streams) {
+      var adData = {
+        "adManager": adManager,
+        "adType": adType,
+        "ad": ad,
+        "streams":streams,
+        "position": -1 //we want it to play immediately
+      };
+      var newAd = new amc.Ad(adData);
+      adQueue.push(newAd);
+    };
+
     amc.notifyPodStarted = function(id, podLength) {
       adPodLength = podLength;
     };
@@ -724,14 +752,14 @@ describe('ad_manager_vast', function() {
 
     vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
-    vastAd = amc.timeline[1];
+    vastAd = adQueue[0];
     vastAdManager.playAd(vastAd);
     expect(adPodLength).to.be(3);
     expect(indexInPod).to.be(2);
 
     vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
-    vastAd = amc.timeline[2];
+    vastAd = adQueue[1];
     vastAdManager.playAd(vastAd);
     expect(adPodLength).to.be(3);
     expect(indexInPod).to.be(3);
@@ -746,6 +774,19 @@ describe('ad_manager_vast', function() {
     var podEndNotified = 0;
     var linearStartNotified = 0;
     var linearEndNotified = 0;
+    var adQueue = [];
+
+    amc.forceAdToPlay = function(adManager, ad, adType, streams) {
+      var adData = {
+        "adManager": adManager,
+        "adType": adType,
+        "ad": ad,
+        "streams":streams,
+        "position": -1 //we want it to play immediately
+      };
+      var newAd = new amc.Ad(adData);
+      adQueue.push(newAd);
+    };
 
     amc.notifyPodStarted = function() {
       podStartNotified++;
@@ -800,7 +841,7 @@ describe('ad_manager_vast', function() {
     expect(linearEndNotified).to.be(1);
     expect(nonLinearStartNotified).to.be(0);
 
-    vastAd = amc.timeline[1];
+    vastAd = adQueue[0];
     vastAdManager.playAd(vastAd);
     expect(podStartNotified).to.be(1);
     expect(podEndNotified).to.be(0);
@@ -816,7 +857,7 @@ describe('ad_manager_vast', function() {
     expect(linearEndNotified).to.be(2);
     expect(nonLinearStartNotified).to.be(0);
 
-    vastAd = amc.timeline[2];
+    vastAd = adQueue[1];
     vastAdManager.playAd(vastAd);
     expect(podStartNotified).to.be(1);
     expect(podEndNotified).to.be(0);
@@ -833,7 +874,7 @@ describe('ad_manager_vast', function() {
     expect(nonLinearStartNotified).to.be(0);
 
     //overlay
-    vastAd = amc.timeline[3];
+    vastAd = adQueue[2];
     vastAdManager.playAd(vastAd);
     expect(podStartNotified).to.be(1);
     expect(podEndNotified).to.be(1);
@@ -848,6 +889,19 @@ describe('ad_manager_vast', function() {
     var podEndNotified = 0;
     var linearStartNotified = 0;
     var linearEndNotified = 0;
+    var adQueue = [];
+
+    amc.forceAdToPlay = function(adManager, ad, adType, streams) {
+      var adData = {
+        "adManager": adManager,
+        "adType": adType,
+        "ad": ad,
+        "streams":streams,
+        "position": -1 //we want it to play immediately
+      };
+      var newAd = new amc.Ad(adData);
+      adQueue.push(newAd);
+    };
 
     amc.notifyPodStarted = function() {
       podStartNotified++;
@@ -896,7 +950,7 @@ describe('ad_manager_vast', function() {
     vastAdManager.cancelAd(vastAd, {
       code : amc.AD_CANCEL_CODE.TIMEOUT
     });
-    vastAd = amc.timeline[1];
+    vastAd = adQueue[0];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
@@ -910,6 +964,19 @@ describe('ad_manager_vast', function() {
     var podEndNotified = 0;
     var linearStartNotified = 0;
     var linearEndNotified = 0;
+    var adQueue = [];
+
+    amc.forceAdToPlay = function(adManager, ad, adType, streams) {
+      var adData = {
+        "adManager": adManager,
+        "adType": adType,
+        "ad": ad,
+        "streams":streams,
+        "position": -1 //we want it to play immediately
+      };
+      var newAd = new amc.Ad(adData);
+      adQueue.push(newAd);
+    };
 
     amc.notifyPodStarted = function() {
       podStartNotified++;
@@ -956,7 +1023,7 @@ describe('ad_manager_vast', function() {
     expect(vastAd.ad.data.id).to.be('6654646');
 
     vastAdManager.adVideoError();
-    vastAd = amc.timeline[1];
+    vastAd = adQueue[0];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -430,7 +430,7 @@ describe('ad_manager_vast', function() {
       'impressionOverlay3Url', 'impressionOverlay4Url', 'impressionOverlay5Url',
       'impressionOverlay6Url' ]);
     expect(vastAd.ad.data.nonLinear).not.to.be(null);
-    expect(vastAd.ad.data.linear).to.eql({'ClickTracking':[],'tracking':{}});
+    expect(vastAd.ad.data.linear).to.eql({});
     expect(vastAd.ad.data.nonLinear.width).to.be('300');
     expect(vastAd.ad.data.nonLinear.height).to.be('60');
     expect(vastAd.ad.data.nonLinear.NonLinearClickThrough).to.be('nonLinearClickThroughUrl');
@@ -513,7 +513,7 @@ describe('ad_manager_vast', function() {
   //  expect(vastAd.ad.data.companion[1].CompanionClickThrough).to.be('companion2ClickThroughUrl');
   //  expect(vastAd.ad.data.companion[1].tracking.creativeView).to.eql(['companion2CreativeViewUrl']);
   //});
-  //TODO: Need to cover PlayADs, overlays and companions once v4 is integrated.
+  //TODO: Need to cover overlays and companions once v4 is integrated.
 
   //Vast 3.0 Tests
 
@@ -651,7 +651,7 @@ describe('ad_manager_vast', function() {
       "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
     initalPlay();
     expect(vastAdManager.initialPlay()).to.be(true);
-    //TODO: expand on these tests
+
     vastAdManager._onVastResponse(vast_ad_mid, linear3_0XMLPodded);
     var vastAd = amc.timeline[0];
     expect(vastAd.ad).to.be.an('object');
@@ -659,20 +659,29 @@ describe('ad_manager_vast', function() {
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
     expect(vastAd.ad.data.linear).not.to.be(null);
     expect(vastAd.ad.data.id).to.be('6654646');
+    vastAdManager.playAd(vastAd);
 
+    vastAdManager.adVideoPlaying();
+    vastAdManager.adVideoEnded();
     vastAd = amc.timeline[1];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
     expect(vastAd.ad.data.linear).not.to.be(null);
     expect(vastAd.ad.data.id).to.be('6654645');
+    vastAdManager.playAd(vastAd);
 
+    vastAdManager.adVideoPlaying();
+    vastAdManager.adVideoEnded();
     vastAd = amc.timeline[2];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
     expect(vastAd.ad.data.linear).not.to.be(null);
     expect(vastAd.ad.data.id).to.be('6654644');
+
+    vastAdManager.adVideoPlaying();
+    vastAdManager.adVideoEnded();
   });
 
   it('Vast 3.0: should provide proper ad pod positions and length to AMC on playAd', function(){
@@ -705,7 +714,7 @@ describe('ad_manager_vast', function() {
       "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
     initalPlay();
     expect(vastAdManager.initialPlay()).to.be(true);
-    //TODO: expand on these tests
+
     vastAdManager._onVastResponse(vast_ad_mid, linear3_0XMLPodded);
 
     var vastAd = amc.timeline[0];
@@ -713,15 +722,22 @@ describe('ad_manager_vast', function() {
     expect(adPodLength).to.be(3);
     expect(indexInPod).to.be(1);
 
+    vastAdManager.adVideoPlaying();
+    vastAdManager.adVideoEnded();
     vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(adPodLength).to.be(3);
     expect(indexInPod).to.be(2);
 
+    vastAdManager.adVideoPlaying();
+    vastAdManager.adVideoEnded();
     vastAd = amc.timeline[2];
     vastAdManager.playAd(vastAd);
     expect(adPodLength).to.be(3);
     expect(indexInPod).to.be(3);
+
+    vastAdManager.adVideoPlaying();
+    vastAdManager.adVideoEnded();
   });
 
   it('Vast 3.0: AMC is notified of linear/nonlinear ad start/end and pod start/end', function(){
@@ -765,7 +781,7 @@ describe('ad_manager_vast', function() {
       "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
     initalPlay();
     expect(vastAdManager.initialPlay()).to.be(true);
-    //TODO: expand on these tests
+
     vastAdManager._onVastResponse(vast_ad_mid, linear3_0XMLPodded);
 
     var vastAd = amc.timeline[0];
@@ -776,6 +792,7 @@ describe('ad_manager_vast', function() {
     expect(linearEndNotified).to.be(0);
     expect(nonLinearStartNotified).to.be(0);
 
+    vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
     expect(podStartNotified).to.be(1);
     expect(podEndNotified).to.be(0);
@@ -791,6 +808,7 @@ describe('ad_manager_vast', function() {
     expect(linearEndNotified).to.be(1);
     expect(nonLinearStartNotified).to.be(0);
 
+    vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
     expect(podStartNotified).to.be(1);
     expect(podEndNotified).to.be(0);
@@ -806,6 +824,7 @@ describe('ad_manager_vast', function() {
     expect(linearEndNotified).to.be(2);
     expect(nonLinearStartNotified).to.be(0);
 
+    vastAdManager.adVideoPlaying();
     vastAdManager.adVideoEnded();
     expect(podStartNotified).to.be(1);
     expect(podEndNotified).to.be(1);
@@ -821,5 +840,66 @@ describe('ad_manager_vast', function() {
     expect(linearStartNotified).to.be(3);
     expect(linearEndNotified).to.be(3);
     expect(nonLinearStartNotified).to.be(1);
+  });
+
+  it('Vast 3.0: On ad playback error, fallback ad will be shown', function(){
+    var nonLinearStartNotified = 0;
+    var podStartNotified = 0;
+    var podEndNotified = 0;
+    var linearStartNotified = 0;
+    var linearEndNotified = 0;
+
+    amc.notifyPodStarted = function() {
+      podStartNotified++;
+    };
+    amc.notifyPodEnded = function() {
+      podEndNotified++;
+    };
+    amc.notifyLinearAdStarted = function() {
+      linearStartNotified++;
+    };
+    amc.notifyLinearAdEnded = function() {
+      linearEndNotified++;
+    };
+    amc.sendURLToLoadAndPlayNonLinearAd = function() {
+      nonLinearStartNotified++;
+    };
+    var embed_code = "embed_code";
+    var vast_ad_mid = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:10,
+      position_type:"t",
+      url:"1.mp4"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad_mid]
+    };
+    vastAdManager.initialize(amc);
+    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
+    initalPlay();
+    expect(vastAdManager.initialPlay()).to.be(true);
+    debugger;
+    vastAdManager._onVastResponse(vast_ad_mid, linear3_0XMLPodded);
+
+    var vastAd = amc.timeline[0];
+    vastAdManager.playAd(vastAd);
+    expect(vastAd.ad).to.be.an('object');
+    expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
+    expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
+    expect(vastAd.ad.data.linear).not.to.be(null);
+    expect(vastAd.ad.data.id).to.be('6654646');
+
+    vastAdManager.adVideoError();
+    vastAd = amc.timeline[1];
+    expect(vastAd.ad).to.be.an('object');
+    expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
+    expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
+    expect(vastAd.ad.data.linear).not.to.be(null);
+    expect(vastAd.ad.data.id).to.be('6654600');
   });
 });

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -883,7 +883,6 @@ describe('ad_manager_vast', function() {
       "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
     initalPlay();
     expect(vastAdManager.initialPlay()).to.be(true);
-    debugger;
     vastAdManager._onVastResponse(vast_ad_mid, linear3_0XMLPodded);
 
     var vastAd = amc.timeline[0];

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -19,10 +19,12 @@ describe('ad_manager_vast', function() {
 
   var linearXMLString = fs.readFileSync(require.resolve("../unit-test-helpers/mock_responses/vast_linear.xml"), "utf8");
   var linear3_0XMLString = fs.readFileSync(require.resolve("../unit-test-helpers/mock_responses/vast_3_0_linear.xml"), "utf8");
+  var linear3_0PoddedXMLString = fs.readFileSync(require.resolve("../unit-test-helpers/mock_responses/vast_3_0_inline_podded.xml"), "utf8");
   var nonLinearXMLString = fs.readFileSync(require.resolve("../unit-test-helpers/mock_responses/vast_overlay.xml"), "utf8");
   var wrapperXMLString = fs.readFileSync(require.resolve("../unit-test-helpers/mock_responses/vast_wrapper.xml"), "utf8");
   var linearXML = OO.$.parseXML(linearXMLString);
   var linear3_0XML = OO.$.parseXML(linear3_0XMLString);
+  var linear3_0XMLPodded = OO.$.parseXML(linear3_0PoddedXMLString);
   var nonLinearXML = OO.$.parseXML(nonLinearXMLString);
   var wrapperXML = OO.$.parseXML(wrapperXMLString);
   var playerParamWrapperDepth = OO.playerParams.maxVastWrapperDepth;
@@ -398,7 +400,6 @@ describe('ad_manager_vast', function() {
     expect(vastAd.ad.data.companion[1].height).to.be('250');
     expect(vastAd.ad.data.companion[1].CompanionClickThrough).to.be('companion2ClickThrough');
     expect(vastAd.ad.data.companion[1].tracking.creativeView).to.eql(['companion2CreativeViewUrl']);
-
   });
 
   it('should parse inline non linear ads', function(){
@@ -584,4 +585,48 @@ describe('ad_manager_vast', function() {
   });
 
   //TODO: Unit test for testing skipoffset with percentage value
+
+  it('Vast 3.0: should parse inline linear podded ads', function(){
+    var embed_code = "embed_code";
+    var vast_ad_mid = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:10,
+      position_type:"t",
+      url:"1.mp4"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad_mid]
+    };
+    vastAdManager.initialize(amc);
+    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
+    initalPlay();
+    expect(vastAdManager.initialPlay()).to.be(true);
+    //TODO: expand on these tests
+    vastAdManager._onVastResponse(vast_ad_mid, linear3_0XMLPodded);
+    var vastAd = amc.timeline[0];
+    expect(vastAd.ad).to.be.an('object');
+    expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
+    expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
+    expect(vastAd.ad.data.linear).not.to.be(null);
+    expect(vastAd.ad.data.id).to.be('6654646');
+
+    vastAd = amc.timeline[1];
+    expect(vastAd.ad).to.be.an('object');
+    expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
+    expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
+    expect(vastAd.ad.data.linear).not.to.be(null);
+    expect(vastAd.ad.data.id).to.be('6654645');
+
+    vastAd = amc.timeline[2];
+    expect(vastAd.ad).to.be.an('object');
+    expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
+    expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
+    expect(vastAd.ad.data.linear).not.to.be(null);
+    expect(vastAd.ad.data.id).to.be('6654644');
+  });
 });

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -470,47 +470,47 @@ describe('ad_manager_vast', function() {
     expect(vastAd.ad.data.companion[1].tracking.creativeView).to.eql(['companion2CreativeViewUrl']);
   });
 
-  it('should parse wrapper ads', function(){
-    var embed_code = "embed_code";
-    var vast_ad_mid = {
-      type: "vast",
-      first_shown: 0,
-      frequency: 2,
-      ad_set_code: "ad_set_code",
-      time:10,
-      position_type:"t",
-      url:"1.jpg"
-    };
-    var content = {
-      embed_code: embed_code,
-      ads: [vast_ad_mid]
-    };
-    vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
-    vastAdManager._onVastResponse(vast_ad_mid, wrapperXML);
-    var vastAd = amc.timeline[0];
-    expect(vastAd.ad).to.be.an('object');
-    expect(vastAd.ad.data.impression).to.eql(['impressionOverlayUrl', 'impressionOverlay2Url', 'impressionOverlay3Url',
-      'impressionOverlay4Url', 'impressionOverlay5Url', 'impressionOverlay6Url']);
-    expect(vastAd.ad.data.companion).to.be.an('array');
-    expect(vastAd.ad.data.companion.length).to.be(2);
-    expect(vastAd.ad.data.companion[0].type).to.be('static');
-    expect(vastAd.ad.data.companion[0].data).to.be('companion.jpg');
-    expect(vastAd.ad.data.companion[0].width).to.be('300');
-    expect(vastAd.ad.data.companion[0].height).to.be('60');
-    expect(vastAd.ad.data.companion[0].CompanionClickThrough).to.be('companionClickThroughUrl');
-    expect(vastAd.ad.data.companion[0].tracking.creativeView).to.eql(['companionCreativeViewUrl']);
-
-    expect(vastAd.ad.data.companion[1].type).to.be('static');
-    expect(vastAd.ad.data.companion[1].data).to.be('companion2.jpg');
-    expect(vastAd.ad.data.companion[1].width).to.be('300');
-    expect(vastAd.ad.data.companion[1].height).to.be('250');
-    expect(vastAd.ad.data.companion[1].CompanionClickThrough).to.be('companion2ClickThroughUrl');
-    expect(vastAd.ad.data.companion[1].tracking.creativeView).to.eql(['companion2CreativeViewUrl']);
-  });
+  //it('should parse wrapper ads', function(){
+  //  var embed_code = "embed_code";
+  //  var vast_ad_mid = {
+  //    type: "vast",
+  //    first_shown: 0,
+  //    frequency: 2,
+  //    ad_set_code: "ad_set_code",
+  //    time:10,
+  //    position_type:"t",
+  //    url:"1.jpg"
+  //  };
+  //  var content = {
+  //    embed_code: embed_code,
+  //    ads: [vast_ad_mid]
+  //  };
+  //  vastAdManager.initialize(amc);
+  //  expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+  //    "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
+  //  initalPlay();
+  //  expect(vastAdManager.initialPlay()).to.be(true);
+  //  vastAdManager._onVastResponse(vast_ad_mid, wrapperXML);
+  //  var vastAd = amc.timeline[0];
+  //  expect(vastAd.ad).to.be.an('object');
+  //  expect(vastAd.ad.data.impression).to.eql(['impressionOverlayUrl', 'impressionOverlay2Url', 'impressionOverlay3Url',
+  //    'impressionOverlay4Url', 'impressionOverlay5Url', 'impressionOverlay6Url']);
+  //  expect(vastAd.ad.data.companion).to.be.an('array');
+  //  expect(vastAd.ad.data.companion.length).to.be(2);
+  //  expect(vastAd.ad.data.companion[0].type).to.be('static');
+  //  expect(vastAd.ad.data.companion[0].data).to.be('companion.jpg');
+  //  expect(vastAd.ad.data.companion[0].width).to.be('300');
+  //  expect(vastAd.ad.data.companion[0].height).to.be('60');
+  //  expect(vastAd.ad.data.companion[0].CompanionClickThrough).to.be('companionClickThroughUrl');
+  //  expect(vastAd.ad.data.companion[0].tracking.creativeView).to.eql(['companionCreativeViewUrl']);
+  //
+  //  expect(vastAd.ad.data.companion[1].type).to.be('static');
+  //  expect(vastAd.ad.data.companion[1].data).to.be('companion2.jpg');
+  //  expect(vastAd.ad.data.companion[1].width).to.be('300');
+  //  expect(vastAd.ad.data.companion[1].height).to.be('250');
+  //  expect(vastAd.ad.data.companion[1].CompanionClickThrough).to.be('companion2ClickThroughUrl');
+  //  expect(vastAd.ad.data.companion[1].tracking.creativeView).to.eql(['companion2CreativeViewUrl']);
+  //});
   //TODO: Need to cover PlayADs, overlays and companions once v4 is integrated.
 
   //Vast 3.0 Tests


### PR DESCRIPTION
-Vast 3.0 podded ads functionality
-supports linear podded ads (tested with a sample tag) and theoretically supports podded ads that end with a nonlinear ad (untested due to lack of test tag)
-removed some wrapper ads functionality and unit test due to them functioning incorrectly before. Will have to be re-added once we tackle wrapper ads