### PR TITLE
[PBI-1459]

### DIFF
--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -248,10 +248,18 @@ OO.Ads.manager(function(_, $) {
       fwContext.setParameter(tv.freewheel.SDK.PARAMETER_RENDERER_VIDEO_DISPLAY_CONTROLS_WHEN_PAUSE, false, tv.freewheel.SDK.PARAMETER_LEVEL_GLOBAL);
       fwContext.setParameter(tv.freewheel.SDK.PARAMETER_RENDERER_VIDEO_CLICK_DETECTION, true, tv.freewheel.SDK.PARAMETER_LEVEL_GLOBAL);
 
-      // position the overlay y index to 0. Alice will take care of positioning the overlay above the control bar
-      // NOTE: If we set renderer.html.coadScriptName we can probably render overlays on our own
-      //       (coad stands for customer owned ad renderer)
-      fwContext.setParameter(tv.freewheel.SDK.PARAMETER_RENDERER_HTML_MARGIN_HEIGHT, 0, tv.freewheel.SDK.PARAMETER_LEVEL_GLOBAL);
+      if (_supportsSecondaryVideoForOverlay()) {
+        //if we can integrate the overlay with Alice, we do not want to add margin height as it will
+        //fit properly within the player skin plugins div without being covered by the control bar
+        fwContext.setParameter(tv.freewheel.SDK.PARAMETER_RENDERER_HTML_MARGIN_HEIGHT, 0, tv.freewheel.SDK.PARAMETER_LEVEL_GLOBAL);
+      } else {
+        // NOTE: If we set renderer.html.coadScriptName we can probably render overlays on our own
+        //       (coad stands for customer owned ad renderer)
+        var controlHeight = amc.ui.rootElement.find(".controlBar");
+        controlHeight = (controlHeight.length == 0) ? 60 : controlHeight.height() + OO.CONSTANTS.CONTROLS_BOTTOM_PADDING;
+        fwContext.setParameter(tv.freewheel.SDK.PARAMETER_RENDERER_HTML_MARGIN_HEIGHT, controlHeight, tv.freewheel.SDK.PARAMETER_LEVEL_GLOBAL);
+      }
+
 
       var companionAds = [
         [
@@ -424,17 +432,24 @@ OO.Ads.manager(function(_, $) {
      * @method Freewheel#_registerDisplayForNonlinearAd
      */
     var _registerDisplayForNonlinearAd = _.bind(function() {
-      if (!overlayContainer) {
-        overlayContainer = amc.ui.playerSkinPluginsElement ? amc.ui.playerSkinPluginsElement[0] : amc.ui.pluginsElement[0];
-      }
+      if (_supportsSecondaryVideoForOverlay()) {
+        if (!overlayContainer) {
+          overlayContainer = amc.ui.playerSkinPluginsElement ? amc.ui.playerSkinPluginsElement[0] : amc.ui.pluginsElement[0];
+        }
 
-      //We need to create a fake video because the setContentVideoElement API requires a video element. The overlay
-      //will be placed in the parent of the provided video element, the player skin plugins element
-      if (!fakeVideo) {
-        fakeVideo = document.createElement('video');
-        overlayContainer.appendChild(fakeVideo);
+        //We need to create a fake video because the setContentVideoElement API requires a video element. The overlay
+        //will be placed in the parent of the provided video element, the player skin plugins element
+        if (!fakeVideo) {
+          fakeVideo = document.createElement('video');
+          overlayContainer.appendChild(fakeVideo);
+        }
+        fwContext.setContentVideoElement(fakeVideo);
+      } else {
+        //on iOS and Android, FW expects the following to be our legit video element when
+        //playing back video ads. If we attempt to use the fake video and then switch to
+        //the real video later, FW places the overlays in unexpected locations.
+        fwContext.setContentVideoElement(amc.ui.ooyalaVideoElement[0]);
       }
-      fwContext.setContentVideoElement(fakeVideo);
     }, this);
 
     /**
@@ -959,6 +974,16 @@ OO.Ads.manager(function(_, $) {
         clearTimeout(adRequestTimeout);
         adRequestTimeout = null;
       }
+    }, this);
+
+    /**
+     * Checks to see if we can use a fake video to trick Freewheel into showing overlays
+     * in a div that is intregrated with Alice.
+     * @private
+     * @method Freewheel#_supportsSecondaryVideoForOverlay
+     */
+    var _supportsSecondaryVideoForOverlay = _.bind(function() {
+      return !OO.isIos;
     }, this);
 
     /**


### PR DESCRIPTION
-fixed an issue where FW video ads would not play on mobile devices
-However, this also makes it overlay ads cannot be interacted with on iOS devices (mainly will affect iPad). We'll have to live with this for now until Freewheel provides us a way to do so