### PR TITLE
[PBI-1484]

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -1299,7 +1299,8 @@ OO.Ads.manager(function(_, $) {
         tracking: {},
         // clickTracking needs to be remembered because it can exist in wrapper ads
         clickTracking: filterEmpty($(linearXml).find("ClickTracking").map(function() { return $(this).text(); })),
-        clickThrough: filterEmpty($(linearXml).find("ClickThrough").map(function() { return $(this).text(); })),
+        //There can only be one clickthrough as per Vast 2.0/3.0 specs and XSDs
+        clickThrough: $(linearXml).find("ClickThrough").text(),
         customClick: filterEmpty($(linearXml).find("CustomClick").map(function() { return $(this).text(); }))
       };
 

--- a/test/unit-test-helpers/mock_responses/vast_linear_no_clickthrough.xml
+++ b/test/unit-test-helpers/mock_responses/vast_linear_no_clickthrough.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="2.0">
+<Ad id="6654644">
+<InLine>
+<AdSystem>GDFP</AdSystem>
+<AdTitle>video</AdTitle>
+<Description>video ad</Description>
+<Error>errorurl</Error>
+<Impression>impressionurl</Impression>
+<Creatives>
+<Creative sequence="1">
+<Linear>
+<Duration>00:00:52</Duration>
+<TrackingEvents>
+<Tracking event="start">starturl</Tracking>
+<Tracking event="firstQuartile">firstQuartileurl</Tracking>
+<Tracking event="midpoint">midpointUrl</Tracking>
+<Tracking event="thirdQuartile">thirdQuartileUrl</Tracking>
+<Tracking event="complete">completeUrl</Tracking>
+<Tracking event="mute">muteUrl</Tracking>
+<Tracking event="unmute">unmuteUrl</Tracking>
+<Tracking event="rewind">rewindUrl</Tracking>
+<Tracking event="pause">pauseUrl</Tracking>
+<Tracking event="resume">resumeUrl</Tracking>
+<Tracking event="fullscreen">fullScreenUrl</Tracking>
+<Tracking event="acceptInvitation"></Tracking>
+<Tracking event="creativeView">creativeViewUrl</Tracking>
+</TrackingEvents>
+<MediaFiles>
+<MediaFile id="GDFP" delivery="progressive" bitrate="338" width="426" height="240" type="video/x-flv" scalable="false" maintainAspectRatio="false">1.flv</MediaFile>
+<MediaFile id="GDFP" delivery="progressive" bitrate="330" width="640" height="360" type="video/mp4" scalable="false" maintainAspectRatio="false">1.mp4</MediaFile>
+<MediaFile id="GDFP" delivery="progressive" bitrate="84" width="176" height="144" type="video/3gpp" scalable="false" maintainAspectRatio="false">1.3gp</MediaFile>
+<MediaFile id="GDFP" delivery="progressive" bitrate="235" width="320" height="240" type="video/3gpp" scalable="false" maintainAspectRatio="false">2.3gp</MediaFile>
+<MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/x-flv" scalable="false" maintainAspectRatio="false">2.flv</MediaFile>
+<MediaFile id="GDFP" delivery="progressive" bitrate="385" width="640" height="360" type="video/webm" scalable="false" maintainAspectRatio="false">1.webm</MediaFile>
+<MediaFile id="GDFP" delivery="progressive" bitrate="538" width="854" height="480" type="video/webm" scalable="false" maintainAspectRatio="false">2.webm</MediaFile>
+<MediaFile id="GDFP" delivery="progressive" bitrate="424" width="854" height="480" type="video/x-flv" scalable="false" maintainAspectRatio="false">3.flv</MediaFile>
+</MediaFiles>
+</Linear>
+</Creative>
+<Creative sequence="1">
+<CompanionAds>
+<Companion id="GDFP" width="728" height="90" >
+<StaticResource creativeType="image/jpeg">1.jpg</StaticResource>
+<TrackingEvents>
+<Tracking event="creativeView">companionCreativeViewUrl</Tracking>
+</TrackingEvents>
+<CompanionClickThrough>companionClickThrough</CompanionClickThrough>
+
+</Companion>
+<Companion id="GDFP" width="300" height="250" >
+<StaticResource creativeType="image/jpeg">2.jpg</StaticResource>
+<TrackingEvents>
+<Tracking event="creativeView">companion2CreativeViewUrl</Tracking>
+</TrackingEvents>
+<CompanionClickThrough>companion2ClickThrough</CompanionClickThrough>
+
+</Companion>
+</CompanionAds>
+</Creative>
+</Creatives>
+<Extensions>
+<Extension>
+<PreviousAdInformation>pK-gf_pnFp8KDQoLCLSVlgMQ7MS3ryY</PreviousAdInformation>
+</Extension>
+<Extension type="geo">
+<Bandwidth>4</Bandwidth>
+</Extension>
+</Extensions>
+</InLine>
+</Ad>
+</VAST>


### PR DESCRIPTION
-fixed an issue where it was possible to trigger a window.open leading to a blank page with a Vast ad without a clickthrough defined
-added a new mock xml to test for when there is no clickthrough defined for a linear ad