### PR TITLE
[PBI-1608]

### DIFF
--- a/js/ad_manager_template.js
+++ b/js/ad_manager_template.js
@@ -85,18 +85,24 @@ OO.Ads.manager(function(_, $) {
      */
     this.buildTimeline = function() {
       var ad1 = {}, ad2 = {};
+      //Video restrictions can be provided at the ad level. If provided, the player will
+      //attempt to create a video element that supports the given video restrictions.
+      //If created, it will exist in amc.ui.adVideoElement by the time playAd is called.
+      //If the element is not created due to lack of support from the available video plugins,
+      //the ad will be skipped
       return [ new amc.Ad({ position: 0,
                             duration: 10,
                             adManager: this.name,
                             ad: ad1,
-                            adType: amc.ADTYPE.LINEAR_VIDEO
+                            adType: amc.ADTYPE.LINEAR_VIDEO,
+                            videoRestrictions: { technology: OO.VIDEO.TECHNOLOGY.HTML5 }
                           }),
                new amc.Ad({ position: 30,
                             duration: 10,
                             adManager: this.name,
                             ad: ad2,
                             adType: amc.ADTYPE.NONLINEAR_OVERLAY
-                          }),
+                          })
              ];
     };
 

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -570,9 +570,6 @@ OO.Ads.manager(function(_, $) {
         return null;
       }
 
-      if (!this.amc.ui.adVideoElement) {
-        this.amc.ui.createAdVideoElement({'mp4' : ''}, vpaidVideoRestrictions);
-      }
       if (typeof vpaidIframe.contentWindow.getVPAIDAd !== 'function' && !this.testMode) {
         OO.log('VPAID 2.0: Required function getVPAIDAd() is not defined.');
         return;
@@ -1073,7 +1070,7 @@ OO.Ads.manager(function(_, $) {
      */
     var generateAd = _.bind(function(metadata) {
       if (!metadata) return false;
-      var type, duration;
+      var duration;
 
       if (!_.isEmpty(metadata.data.linear.mediaFiles)) {
         duration = OO.timeStringToSeconds(metadata.data.linear.duration);
@@ -1083,10 +1080,16 @@ OO.Ads.manager(function(_, $) {
         duration = metadata.data.nonLinear.duration ?  OO.timeStringToSeconds(metadata.data.nonLinear.duration) : 0;
       }
 
-      return new this.amc.Ad({
+      var ad = new this.amc.Ad({
         position: metadata.positionSeconds, duration: duration, adManager: this.name,
         ad: metadata, adType: metadata.data.type, streams: metadata.streams
       });
+
+      if (metadata.data.adType === "vpaid") {
+        ad.videoRestrictions = vpaidVideoRestrictions;
+      }
+
+      return ad;
     }, this);
 
     /**

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -491,6 +491,7 @@ describe('ad_manager_vast', function() {
     expect(errorType.length).to.be(0);
     var vastAd = amc.timeline[0];
     expect(vastAd.ad).to.be.an('object');
+    expect(vastAd.videoRestrictions).to.be(undefined);
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
     expect(vastAd.ad.data.linear).not.to.be(null);
@@ -1848,6 +1849,8 @@ describe('ad_manager_vast', function() {
     expect(ad.position).to.eql(0);
     var parsedAd = global.vpaidAd.ad.data;
     expect(ad.ad).to.be.an('object');
+    expect(ad.videoRestrictions).to.eql({ technology: OO.VIDEO.TECHNOLOGY.HTML5,
+      features: [OO.VIDEO.FEATURE.VIDEO_OBJECT_SHARING_GIVE] });
     expect(ad.ad.adPodIndex).to.eql(1);
     expect(ad.ad.adPodLength).to.eql(1);
     expect(ad.ad.sequence).to.be(null);


### PR DESCRIPTION
-VPAID in the Vast ad manager will now provide ad level video restrictions in the ad object that is provided to the AMC