### PR TITLE
Pbi 1648

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -891,7 +891,6 @@ OO.Ads.manager(function(_, $) {
      * @param  {object} adWrapper An object of type AdManagerController.Ad containing ad metadata
      */
     var _playLoadedAd = _.bind(function(adWrapper) {
-      this.amc.ui.createAdVideoElement(adWrapper.streams);
       var isVPaid = _isVpaidAd(currentAd);
 
       // When the ad is done, trigger callback

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -116,9 +116,6 @@ OO.Ads.manager(function(_, $) {
                                             AD_USER_MINIMIZE          : 'AdUserMinimize'
                                           };
 
-    // If `false` prerolls won't load until intialPlay
-    this.preload                          = false;
-
     // VAST Parsed variables
     this.format                           = null;
     this.node                             = null;
@@ -679,32 +676,26 @@ OO.Ads.manager(function(_, $) {
 
       this.ready = true;
       this.amc.onAdManagerReady();
-
-      var adsPreloaded = !this.preload;
-      if (this.preload) {
-        adsPreloaded = this.loadPreRolls();
-      }
-      return adsPreloaded;
     };
 
     /**
-     * Checks to see if the current metadata contains any ads that are pre-rolls and of type vast. If there are any
+     * [DEPRECATED]Checks to see if the current metadata contains any ads that are pre-rolls and of type vast. If there are any
      * then it will load the ads.
      * @public
-     * @method Vast#loadPreRolls
+     * @method Vast#loadPreRolls[DEPRECATED]
      */
     this.loadPreRolls = function() {
-    //  return findAndLoadAd("pre");
+      //deprecated
     };
 
     /**
-     * Checks the metadata for any remaining ads of type vast that are not pre-rolls.
+     * [DEPRECATED]Checks the metadata for any remaining ads of type vast that are not pre-rolls.
      * If it finds any then it will load them.
      * @public
-     * @method Vast#loadAllVastAds
+     * @method Vast#loadAllVastAds[DEPRECATED]
      */
     this.loadAllVastAds = function() {
-    //  return findAndLoadAd("midPost");
+      //deprecated
 
     };
 
@@ -740,13 +731,13 @@ OO.Ads.manager(function(_, $) {
    /**
      * Finds ads based on the position provided to the function.
      * @private
-     * @method Vast#findAndLoadAd
+     * @method Vast#loadAd
      * @param {string} position The position of the ad to be loaded. 'pre' (preroll), 'midPost' (midroll and post rolls)
      * 'all' (all positions).
      * @returns {boolean} returns true if it found an ad or ads to load otherwise it returns false. This is only used for
      * unit tests.
      */
-    var findAndLoadAd = _.bind(function(amcAd) {
+    var loadAd = _.bind(function(amcAd) {
       var loadedAds = false;
       var override = false;
       var ad = amcAd.ad;
@@ -795,13 +786,13 @@ OO.Ads.manager(function(_, $) {
      * @method Vast#buildTimeline
      */
     this.buildTimeline = function() {
-      //TODO check if preloading, if true then don't add these ad requests to the timeline
       var timeline = [];
       if (this.allAdInfo && _.isArray(this.allAdInfo))
       {
         for (var i = 0; i < this.allAdInfo.length; i++)
         {
           var ad = this.allAdInfo[i];
+          //use linear overlay as fake ad so we don't have to specify stream type.
           var adData = {
             adManager: this.name,
             ad: ad,
@@ -889,14 +880,14 @@ OO.Ads.manager(function(_, $) {
       if (adWrapper) {
         currentAd = adWrapper;
         if (currentAd.isAdRequest) {
-          findAndLoadAd(currentAd);
+          loadAd(currentAd);
         } else {
-          this.playCurrentAd(adWrapper);
+          playLoadedAd(adWrapper);
         }
       }
     }
 
-    this.playCurrentAd = function(adWrapper) {
+    var playLoadedAd = _.bind(function(adWrapper) {
       this.amc.ui.createAdVideoElement(adWrapper.streams);
       var isVPaid = _isVpaidAd(currentAd);
 
@@ -942,7 +933,7 @@ OO.Ads.manager(function(_, $) {
         this.checkCompanionAds(adWrapper.ad);
         initSkipAdOffset(adWrapper);
       }
-    };
+    }, this);
 
     /**
      * Determine if a Vast ad is skippable, and if so, when the skip ad button should be displayed.

--- a/test/unit-test-helpers/mock_amc.js
+++ b/test/unit-test-helpers/mock_amc.js
@@ -42,7 +42,8 @@ fake_amc = function() {
     playerSkinPluginsElement : $("<div>", {}),
     adWrapper : $("<div>", {}),
     transitionToAd: function(){},
-    transitionToMainContent: function(){}
+    transitionToMainContent: function(){},
+    createAdVideoElement: function() {}
   };
   this.platform = {};
   this.pageSettings = {};

--- a/test/unit-test-helpers/mock_amc.js
+++ b/test/unit-test-helpers/mock_amc.js
@@ -42,8 +42,7 @@ fake_amc = function() {
     playerSkinPluginsElement : $("<div>", {}),
     adWrapper : $("<div>", {}),
     transitionToAd: function(){},
-    transitionToMainContent: function(){},
-    createAdVideoElement: function() {}
+    transitionToMainContent: function(){}
   };
   this.platform = {};
   this.pageSettings = {};

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -336,11 +336,11 @@ describe('ad_manager_vast', function() {
     expect(amc.timeline.length).to.be(3);
     //test assumes the timeline isn't being sorted by the amc. If that changes, this will need to change accordingly.
     expect(amc.timeline[0].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
-    expect(amc.timeline[0].isAdRequest).to.be(true);
+    expect(amc.timeline[0].ad.type).to.be('adRequest');
     expect(amc.timeline[1].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
-    expect(amc.timeline[1].isAdRequest).to.be(true);
+    expect(amc.timeline[1].ad.type).to.be('adRequest');
     expect(amc.timeline[2].adType).to.be(amc.ADTYPE.LINEAR_VIDEO);
-    expect(amc.timeline[2].isAdRequest).to.be(undefined);
+    expect(amc.timeline[2].ad.type).to.be(undefined);
   });
 
   it('Init: test postroll appears in buildTimeline', function(){
@@ -364,7 +364,7 @@ describe('ad_manager_vast', function() {
       "html5_ad_server": "http://blah"}, {}, content);
     expect(amc.timeline.length).to.be(1);
     expect(amc.timeline[0].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
-    expect(amc.timeline[0].isAdRequest).to.be(true);
+    expect(amc.timeline[0].ad.type).to.be('adRequest');
   });
 
   it('should invalid vast', function(){
@@ -1781,7 +1781,7 @@ describe('ad_manager_vast', function() {
     };
     vastAdManager.initialize(amc);
     vastAdManager.loadMetadata({"tagUrl": "http://blahblah"}, {}, content);
-    amc.timeline[0].id = "asdf";
+    amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
     vastAdManager.playAd(amc.timeline[0]);
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -97,7 +97,6 @@ describe('ad_manager_vast', function() {
     vastAdManager.initialize(amc);
     vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
       "html5_ad_server": "http://blah"}, {}, content);
-    amc.timeline = vastAdManager.buildTimeline();
   };
 
   var vpaidInitialize = function(xml) {
@@ -120,13 +119,14 @@ describe('ad_manager_vast', function() {
         };
 
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata(server, {}, content)).to.be(true);
-    initalPlay();
+    vastAdManager.loadMetadata(server, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     xml = xml || vpaidLinearXML;
     vastAdManager.onVastResponse(preroll, xml);
   };
 
-  var initalPlay = function() {
+  var initialPlay = function() {
     amc.callbacks[amc.EVENTS.INITIAL_PLAY_REQUESTED]();
   };
 
@@ -165,6 +165,9 @@ describe('ad_manager_vast', function() {
 
   beforeEach(function() {
     amc = new fake_amc();
+    amc.adManagerList = [];
+    amc.onAdManagerReady = function() {this.timeline = this.adManagerList[0].buildTimeline()};
+    amc.adManagerList.push(vastAdManager);
     OO.playerParams.maxVastWrapperDepth = 2;
     errorType = [];
     pixelPingCalled= false;
@@ -243,7 +246,7 @@ describe('ad_manager_vast', function() {
     expect(vastAdManager.ready).to.be(true);
   });
 
-  it('Init: preroll was loaded', function(){
+  it('Init: preroll returned in buildTimeline()', function(){
     var embed_code = "embed_code";
     var vast_ad = {
       type: "vast",
@@ -259,18 +262,22 @@ describe('ad_manager_vast', function() {
     };
 
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    var timeline = amc.timeline;
+    expect(timeline.length).to.be(1);
+    expect(timeline[0].position).to.be(0);
+    expect(timeline[0].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
   });
 
-  it('Init: no preroll was found or loaded', function(){
+  it('Init: test midroll return in buildTimeline', function(){
     var embed_code = "embed_code";
     var vast_ad = {
       type: "vast",
       first_shown: 0,
       frequency: 2,
       ad_set_code: "ad_set_code",
-      time:10,
+      time:10000,
       position_type:"t"
     };
     var content = {
@@ -279,37 +286,15 @@ describe('ad_manager_vast', function() {
     };
 
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    var timeline = amc.timeline;
+    expect(timeline.length).to.be(1);
+    expect(timeline[0].position).to.be(10);
+        expect(timeline[0].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
   });
 
-  it('Init: no preroll but midroll was found or loaded after initial play', function(){
-    var embed_code = "embed_code";
-    var vast_ad = {
-      type: "vast",
-      first_shown: 0,
-      frequency: 2,
-      ad_set_code: "ad_set_code",
-      time:10,
-      position_type:"t",
-      url:"1.mp4"
-    };
-    var content = {
-      embed_code: embed_code,
-      ads: [vast_ad]
-    };
-
-    vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
-    vastAdManager.onVastResponse(vast_ad, linearXML);
-    expect(errorType.length).to.be(0);
-    expect(amc.timeline.length).to.be(1);
-  });
-
-  it('Init: preroll loaded before play and midroll after initial play', function(){
+  it('Init: test preroll and midroll appear in buildTimeline() and prerolls loads on initialPlay', function(){
     var embed_code = "embed_code";
     var vast_ad_pre = {
       type: "vast",
@@ -334,21 +319,31 @@ describe('ad_manager_vast', function() {
     };
 
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
 
-    vastAdManager.onVastResponse(vast_ad_pre, linearXML);
-    expect(errorType.length).to.be(0);
-    expect(amc.timeline.length).to.be(1);
-
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
-    vastAdManager.onVastResponse(vast_ad_mid, linearXML);
+    //vastAdManager.onVastResponse(vast_ad_pre, linearXML);
     expect(errorType.length).to.be(0);
     expect(amc.timeline.length).to.be(2);
+    expect(amc.timeline[0].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
+    expect(amc.timeline[1].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
+
+    initialPlay();
+    vastAdManager.initialPlay();
+    vastAdManager.onVastResponse(vast_ad_pre, linearXML);
+    expect(errorType.length).to.be(0);
+    //test that real ad gets added to timeline when it's loaded.
+    expect(amc.timeline.length).to.be(3);
+    //test assumes the timeline isn't being sorted by the amc. If that changes, this will need to change accordingly.
+    expect(amc.timeline[0].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
+    expect(amc.timeline[0].isAdRequest).to.be(true);
+    expect(amc.timeline[1].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
+    expect(amc.timeline[1].isAdRequest).to.be(true);
+    expect(amc.timeline[2].adType).to.be(amc.ADTYPE.LINEAR_VIDEO);
+    expect(amc.timeline[2].isAdRequest).to.be(undefined);
   });
 
-  it('Init: postroll after initial play', function(){
+  it('Init: test postroll appears in buildTimeline', function(){
     var embed_code = "embed_code";
     var vast_ad_post = {
       type: "vast",
@@ -365,66 +360,11 @@ describe('ad_manager_vast', function() {
     };
 
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    expect(amc.timeline.length).to.be(0);
-
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
-    vastAdManager.onVastResponse(vast_ad_post, linearXML);
-    expect(errorType.length).to.be(0);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
     expect(amc.timeline.length).to.be(1);
-  });
-
-  it('Init: preroll loaded before play, then midroll and postroll after initial play', function(){
-    var embed_code = "embed_code";
-    var vast_ad_pre = {
-      type: "vast",
-      first_shown: 0,
-      frequency: 2,
-      ad_set_code: "ad_set_code",
-      time:0,
-      position_type:"t"
-    };
-    var vast_ad_mid = {
-      type: "vast",
-      first_shown: 0,
-      frequency: 2,
-      ad_set_code: "ad_set_code",
-      time:10,
-      position_type:"t",
-      url:"1.mp4"
-    };
-    var vast_ad_post = {
-      type: "vast",
-      first_shown: 0,
-      frequency: 2,
-      ad_set_code: "ad_set_code",
-      time:1000000000,
-      position_type:"t",
-      url:"1.mp4"
-    };
-    var content = {
-      embed_code: embed_code,
-      ads: [vast_ad_pre, vast_ad_mid, vast_ad_post]
-    };
-
-    vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(true);
-    vastAdManager.onVastResponse(vast_ad_pre, linearXML);
-    expect(errorType.length).to.be(0);
-    expect(amc.timeline.length).to.be(1);
-
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
-    vastAdManager.onVastResponse(vast_ad_mid, linearXML);
-    expect(errorType.length).to.be(0);
-    expect(amc.timeline.length).to.be(2);
-
-    vastAdManager.onVastResponse(vast_ad_post, linearXML);
-    expect(errorType.length).to.be(0);
-    expect(amc.timeline.length).to.be(3);
+    expect(amc.timeline[0].adType).to.be(amc.ADTYPE.LINEAR_OVERLAY);
+    expect(amc.timeline[0].isAdRequest).to.be(true);
   });
 
   it('should invalid vast', function(){
@@ -443,28 +383,31 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    expect(amc.timeline.length).to.be(1);
+
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad,'<VAST></VAST>');
+
     expect(errorType.length > 0).to.be(true);
-    expect(amc.timeline.length).to.be(0);
+    expect(amc.timeline.length).to.be(1);
     errorType = [];
 
     vastAdManager.onVastResponse(null,linearXML);
     expect(errorType.length > 0).to.be(true);
-    expect(amc.timeline.length).to.be(0);
+    expect(amc.timeline.length).to.be(1);
     errorType = [];
 
     vastAdManager.onVastResponse(vast_ad, '<VAST version="2.1"></VAST>');
     expect(errorType.length > 0).to.be(true);
-    expect(amc.timeline.length).to.be(0);
+    expect(amc.timeline.length).to.be(1);
     errorType = [];
 
     vastAdManager.onVastResponse(null, '<VAST version="2.0"></VAST>');
     expect(errorType.length > 0).to.be(true);
-    expect(amc.timeline.length).to.be(0);
+    expect(amc.timeline.length).to.be(1);
   });
 
   it('should parse inline linear ads', function(){
@@ -483,13 +426,14 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linearXML);
+
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
@@ -541,13 +485,13 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, nonLinearXML);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionOverlayUrl', 'impressionOverlay2Url',
@@ -612,10 +556,10 @@ describe('ad_manager_vast', function() {
   //    ads: [vast_ad_mid]
   //  };
   //  vastAdManager.initialize(amc);
-  //  expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-  //    "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-  //  initalPlay();
-  //  expect(vastAdManager.initialPlay()).to.be(true);
+  //  vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+  //    "html5_ad_server": "http://blah"}, {}, content);
+  //  initialPlay();
+  //  vastAdManager.initialPlay();
   //  vastAdManager.onVastResponse(vast_ad_mid, wrapperXML);
   //  var vastAd = amc.timeline[0];
   //  expect(vastAd.ad).to.be.an('object');
@@ -664,13 +608,13 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linear3_0XML);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(allowSkipButton).to.be(true);
     //value in MS. vast_3_0_linear.xml mock response has value of 00:00:05, which is 5 seconds
@@ -699,13 +643,13 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linearXML);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(allowSkipButton).to.be(true);
     expect(skipOffset).to.be(undefined);
@@ -746,13 +690,13 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linearXML);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(adPodLength).to.be(1);
     expect(indexInPod).to.be(1);
@@ -782,13 +726,13 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linearXML);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     vastAdManager.playerClicked(vastAd, true);
     //1 clickthrough url is defined in vast_linear.xml
@@ -819,13 +763,13 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linearNoClickthroughXML);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     vastAdManager.playerClicked(vastAd, true);
     expect(openedUrls.length).to.be(0);
@@ -860,14 +804,14 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
 
     vastAdManager.onVastResponse(vast_ad_mid, linearXML2Ads);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
@@ -918,14 +862,14 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
 
     vastAdManager.onVastResponse(vast_ad_mid, linear3_0XMLPodded);
     expect(errorType.length).to.be(0);
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
     expect(vastAd.ad.data.impression).to.eql([ 'impressionurl' ]);
@@ -997,15 +941,15 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
 
     vastAdManager.onVastResponse(vast_ad_mid, linear3_0XMLPodded);
     expect(errorType.length).to.be(0);
 
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(adPodLength).to.be(3);
     expect(indexInPod).to.be(1);
@@ -1078,15 +1022,15 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
 
     vastAdManager.onVastResponse(vast_ad_mid, linear3_0XMLPodded);
     expect(errorType.length).to.be(0);
 
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(podStartNotified).to.be(1);
     expect(podEndNotified).to.be(0);
@@ -1194,14 +1138,14 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linear3_0XMLPodded);
     expect(errorType.length).to.be(0);
 
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
@@ -1270,14 +1214,14 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad_mid]
     };
     vastAdManager.initialize(amc);
-    expect(vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
-      "html5_ad_server": "http://blah"}, {}, content)).to.be(false);
-    initalPlay();
-    expect(vastAdManager.initialPlay()).to.be(true);
+    vastAdManager.loadMetadata({"html5_ssl_ad_server":"https://blah",
+      "html5_ad_server": "http://blah"}, {}, content);
+    initialPlay();
+    vastAdManager.initialPlay();
     vastAdManager.onVastResponse(vast_ad_mid, linear3_0XMLPodded);
     expect(errorType.length).to.be(0);
 
-    var vastAd = amc.timeline[0];
+    var vastAd = amc.timeline[1];
     vastAdManager.playAd(vastAd);
     expect(vastAd.ad).to.be.an('object');
     expect(vastAd.ad.data.error).to.eql([ 'errorurl' ]);
@@ -1837,12 +1781,14 @@ describe('ad_manager_vast', function() {
     };
     vastAdManager.initialize(amc);
     vastAdManager.loadMetadata({"tagUrl": "http://blahblah"}, {}, content);
+    amc.timeline[0].id = "asdf";
+    vastAdManager.playAd(amc.timeline[0]);
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });
 
   it('VPAID 2.0: Should parse VPAID linear creative', function() {
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     expect(ad).to.be.an('object');
     expect(ad.duration).to.eql(16);
     expect(ad.position).to.eql(0);
@@ -1871,7 +1817,7 @@ describe('ad_manager_vast', function() {
 
   it('VPAID 2.0: Should create slot and video slot', function() {
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(_.isElement(vastAdManager._slot)).to.be(true);
@@ -1880,7 +1826,7 @@ describe('ad_manager_vast', function() {
 
   it('VPAID 2.0: initAd should be called after validations', function() {
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(global.vpaid.adInit).to.be(true)
@@ -1889,7 +1835,7 @@ describe('ad_manager_vast', function() {
   it('VPAID 2.0: initAd should not be called when any required ad unit function is missing', function() {
     vpaidInitialize();
     global.vpaid.getVPAIDAd = function() { return new global.vpaid.missingFnVPAIDAd(); };
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(global.vpaid.adInit).to.be(false)
@@ -1898,7 +1844,7 @@ describe('ad_manager_vast', function() {
   it('VPAID 2.0: initAd should not be called when using incorrect version <2.0', function() {
     vpaidInitialize();
     global.vpaid.getVPAIDAd = function() { return new global.vpaid.incorrectVersionVPAIDAd(); };
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(global.vpaid.adInit).to.be(false)
@@ -1916,7 +1862,7 @@ describe('ad_manager_vast', function() {
       linearStartedNotified++;
     };
 
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(global.vpaid.adStarted).to.be(true);
@@ -1936,7 +1882,7 @@ describe('ad_manager_vast', function() {
       linearEndNotified++;
     };
 
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     ad.vpaidAd.adVideoCompleted();
@@ -1957,7 +1903,7 @@ describe('ad_manager_vast', function() {
       linearEndNotified++;
     };
 
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     vastAdManager.cancelAd(ad, {
@@ -1976,7 +1922,7 @@ describe('ad_manager_vast', function() {
       skipOffset = offset;
     };
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
 
@@ -1994,7 +1940,7 @@ describe('ad_manager_vast', function() {
       companion = companionAds;
     };
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(companion).to.eql(parsedAd.companion);
@@ -2012,7 +1958,7 @@ describe('ad_manager_vast', function() {
       linearEndNotified++;
     };
 
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     vastAdManager.adVideoEnded();
@@ -2028,7 +1974,7 @@ describe('ad_manager_vast', function() {
       adUnitHandling = false;
     };
 
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     ad.vpaidAd.sendClick(false);
@@ -2045,7 +1991,7 @@ describe('ad_manager_vast', function() {
     amc.notifyLinearAdStarted = function() {
       linearStartedNotified++;
     };
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     amc.adManagerSettings['linearAdSkipButtonStartTime'] = 5;
@@ -2057,7 +2003,7 @@ describe('ad_manager_vast', function() {
 
   it('VPAID 2.0: Should parse and send ad parameters', function() {
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(JSON.parse(ad.ad.adParams)).to.eql(ad.vpaidAd.properties.adParameters);
@@ -2069,7 +2015,7 @@ describe('ad_manager_vast', function() {
       hidePlayerUi = true;
     };
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(hidePlayerUi).to.be(true);
@@ -2077,7 +2023,7 @@ describe('ad_manager_vast', function() {
 
   it('VPAID 2.0: Should resize ad unit on size changed', function() {
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(ad.vpaidAd.properties.width).to.be(100);
@@ -2091,7 +2037,7 @@ describe('ad_manager_vast', function() {
 
   it('VPAID 2.0: Should resize ad unit on fullscreen change', function() {
     vpaidInitialize();
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(ad.vpaidAd.properties.width).to.be(100);
@@ -2109,7 +2055,7 @@ describe('ad_manager_vast', function() {
       companion = companionAds;
     };
     vpaidInitialize(vpaidNoCompanionXML);
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     vastAdManager.initializeAd();
     expect(companion).to.eql({companion:{}});
@@ -2117,7 +2063,7 @@ describe('ad_manager_vast', function() {
 
   it('VPAID 2.0: should fail if media file value is empty', function() {
     vpaidInitialize(vpaidLinearNoValuesXML);
-    var ad = amc.timeline[0];
+    var ad = amc.timeline[1];
     vastAdManager.playAd(ad);
     expect(vastAdManager.initializeAd()).to.be(null);
     expect(ad.duration).to.eql(16);


### PR DESCRIPTION
Taking out preloading of vast ads. Ads now load only when they are about to play, using a placeholder linear-overlay in the timeline(similar to what we do in freewheel).  And unit tests were updated to reflect the changes.