### PR TITLE
PSDK-520: Fix timeout bug on iOS due to wrong expectations of the plu…

### DIFF
--- a/js/pulse.js
+++ b/js/pulse.js
@@ -47,7 +47,6 @@
              */
             this.initialize = function(adManagerController, playerId) {
                 amc = adManagerController; // the AMC is how the code interacts with the player
-                amc.adManagerWillControlAds();
                 pulseAdManagers[playerId] = this;
 
                 // Add any player event listeners now
@@ -651,6 +650,7 @@
 
             var _onInitialPlay = function() {
                 isWaitingForPrerolls = true;
+                amc.adManagerWillControlAds();
                 if(adModuleJsReady){
                     if(!adPlayer){
                         this.tryInitAdPlayer();

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -47,6 +47,7 @@
              */
             this.initialize = function(adManagerController, playerId) {
                 amc = adManagerController; // the AMC is how the code interacts with the player
+                amc.adManagerWillControlAds();
                 pulseAdManagers[playerId] = this;
 
                 // Add any player event listeners now
@@ -69,7 +70,8 @@
             this.registerUi = function() {
                 this.ui = amc.ui;
 
-                if(this.ui.useSingleVideoElement){
+                if (amc.ui.useSingleVideoElement && !this.sharedVideoElement && amc.ui.ooyalaVideoElement[0] &&
+                    (amc.ui.ooyalaVideoElement[0].className === "video")) {
                     this.sharedVideoElement = this.ui.ooyalaVideoElement[0];
                 }
             }
@@ -523,6 +525,7 @@
                 isWaitingForPrerolls = false;
 
                 if(isInAdMode){
+                    this.notifyAdPodEnded();
                     if(adPlayer){
                         adPlayer.contentStarted();
                     }
@@ -549,7 +552,8 @@
                     waitingForContentPause = true;
 
                 }
-                if(isWaitingForPrerolls){
+
+                if(isInAdMode || (isWaitingForPrerolls && ! this.ui.useSingleVideoElement)){
                     return true;
                 }
                 return false;
@@ -589,7 +593,6 @@
             };
 
             var _onContentFinished = function(){
-                amc.adManagerWillControlAds();
                 this._contentFinished = true;
                 if(adPlayer)
                     adPlayer.contentFinished();


### PR DESCRIPTION
…gin on the order of the events coming from the player

@pilievOoyala Can you review this? The timing with which we received the playAd call was  different on iOS which caused one of our variables (the pod ID we used to tell we started a pod) to be null in some cases. This commit fixes that.