### PR TITLE
[raise-timeout] Raising IMA's ad requesting time-out to 5 seconds.

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -50,7 +50,7 @@ require("../html5-common/js/utils/utils.js");
 
       //Constants
       var DEFAULT_IMA_IFRAME_Z_INDEX = 10004;
-      var DEFAULT_ADS_REQUEST_TIME_OUT = 3000;
+      var DEFAULT_ADS_REQUEST_TIME_OUT = 5000;
       var AD_RULES_POSITION_TYPE = 'r';
       var NON_AD_RULES_POSITION_TYPE = 't';
       var NON_AD_RULES_PERCENT_POSITION_TYPE = 'p';


### PR DESCRIPTION
We are raising the timeout because VPAID 1.0 ads seem to take longer to load and this will hopefully eliminate some of the customer headache of losing revenue from ads failing to load in time.