### PR TITLE
[PBW-5938]

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1821,14 +1821,12 @@ require("../html5-common/js/utils/utils.js");
             }
             else
             {
-              //End the fake ad here
               _endCurrentAdPod(this.currentAMCAdPod.isRequest);
             }
           }
           else
           {
-            //End the fake ad here
-            _endCurrentAdPod(this.currentAMCAdPod.isRequest);
+            _endCurrentAdPod(true);
           }
         }
 

--- a/test/unit-test-helpers/mock_amc.js
+++ b/test/unit-test-helpers/mock_amc.js
@@ -60,7 +60,8 @@ fake_amc = function() {
     playerSkinPluginsElement : $("<div>", {}),
     adWrapper : $("<div>", {}),
     transitionToAd: function(){},
-    transitionToMainContent: function(){}
+    transitionToMainContent: function(){},
+    useSingleVideoElement: false
   };
   this.platform = {};
   this.pageSettings = {};


### PR DESCRIPTION
-fixed an issue where a linear video playing in single video element mode would not end the current ad pod when it finishes
-removed outdated comments
-fixed an issue in the ima unit tests where the amc was not a new object at the beginning of each test