### PR TITLE
[PBI-1958]

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -241,7 +241,7 @@ require("../html5-common/js/utils/utils.js");
         this.maxAdsRequestTimeout = DEFAULT_ADS_REQUEST_TIME_OUT;
         if (_amc.adManagerSettings.hasOwnProperty(_amc.AD_SETTINGS.AD_LOAD_TIMEOUT))
         {
-          this.maxAdsRequestTimeout = _amc.adManagerSettings[_amc.AD_SETTINGS.AD_LOAD_TIMEOUT] * 1000;
+          this.maxAdsRequestTimeout = _amc.adManagerSettings[_amc.AD_SETTINGS.AD_LOAD_TIMEOUT];
         }
 
         this.additionalAdTagParameters = null;


### PR DESCRIPTION
Remove second -> millisecond conversion of AD_LOAD_TIMEOUT constant because it is already converted