### PR TITLE
Pbi 2015

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -34,8 +34,6 @@ OO.Ads.manager(function(_, $) {
    * @property {boolean} loaded Set to true once the ad has been loaded successfully
    * @property {string} embedCode Keeps track of the embed code of the movie that is currently playing
    * @property {string} loaderId Unique id name for the loader, which is required by the API
-   * @property {object} movieMd Contains the metadata of the main movie
-   * @property {string} adURLOverride If the page level params override the ad url then it is stored here
    * @property {object} lastOverlayAd Contains the ad information for the overlay that was displayed before it was removed.
    * This is used so we know what to add back to the screen after the video ad is done and the main video hasn't ended.
    * @property {object} adTrackingInfo The object that holds each individual ad id's tracking urls (including error reporting).
@@ -54,10 +52,8 @@ OO.Ads.manager(function(_, $) {
     this.ready  = false;
     this.currentDepth = 0;
     this.loaded = false;
-    this.embedCode = 'unkown';
+    this.embedCode = 'unknown';
     this.loaderId = 'OoVastAdsLoader' + _.uniqueId;
-    this.movieMd = null;
-    this.adURLOverride;
     this.lastOverlayAd;
     this.adTrackingInfo = {};
     this.VAST_AD_CONTAINER = '#vast_ad_container';
@@ -69,10 +65,9 @@ OO.Ads.manager(function(_, $) {
     // VPAID Variables
     var vpaidVideoRestrictions          = { technology: OO.VIDEO.TECHNOLOGY.HTML5,
                                             features: [OO.VIDEO.FEATURE.VIDEO_OBJECT_SHARING_GIVE] };
-    this.embedCode                      = 'unkown';
+    this.mainContentDuration            = -1;
     this.testMode                       = false;
 
-    this.adURLOverride                  = '';
     this.allAdInfo                      = null;
     this.showLinearAdSkipButton         = false;
     var vpaidIframe                          = null;
@@ -737,31 +732,26 @@ OO.Ads.manager(function(_, $) {
      * @param {object} movieMetadata Contains the movie metadata that is currently loaded
      */
     this.loadMetadata = function(pbMetadata, baseBacklotMetadata, movieMetadata) {
-      // Interpret the data from the page and backlot - possibly combine this function with initialize
+      this.mainContentDuration = movieMetadata.duration/1000;
       this.embedCode = this.amc.currentEmbedCode;
-      this.allAdInfo = movieMetadata.ads || pbMetadata.all_ads;
-      this.movieMd = movieMetadata;
-      if (pbMetadata) {
-        if (pbMetadata.tagUrl) {
-          this.adURLOverride = pbMetadata.tagUrl;
+      // We want to prioritize the page level setting over the movie metadata
+      this.allAdInfo = (pbMetadata ? pbMetadata.all_ads : null) || (movieMetadata ? movieMetadata.ads : {});
+
+      if (pbMetadata && pbMetadata.vpaidTimeout) {
+        if (_.isNumber(pbMetadata.vpaidTimeout.iframe) && pbMetadata.vpaidTimeout.iframe >= 0) {
+          this.VPAID_AD_IFRAME_TIMEOUT = pbMetadata.vpaidTimeout.iframe * 1000;
         }
 
-        if (pbMetadata.vpaidTimeout) {
-          if (_.isNumber(pbMetadata.vpaidTimeout.iframe) && pbMetadata.vpaidTimeout.iframe >= 0) {
-            this.VPAID_AD_IFRAME_TIMEOUT = pbMetadata.vpaidTimeout.iframe * 1000;
-          }
+        if (_.isNumber(pbMetadata.vpaidTimeout.loaded) && pbMetadata.vpaidTimeout.loaded >= 0) {
+          this.VPAID_AD_LOADED_TIMEOUT = pbMetadata.vpaidTimeout.loaded * 1000;
+        }
 
-          if (_.isNumber(pbMetadata.vpaidTimeout.loaded) && pbMetadata.vpaidTimeout.loaded >= 0) {
-            this.VPAID_AD_LOADED_TIMEOUT = pbMetadata.vpaidTimeout.loaded * 1000;
-          }
+        if (_.isNumber(pbMetadata.vpaidTimeout.started) && pbMetadata.vpaidTimeout.started >= 0) {
+          this.VPAID_AD_STARTED_TIMEOUT = pbMetadata.vpaidTimeout.started * 1000;
+        }
 
-          if (_.isNumber(pbMetadata.vpaidTimeout.started) && pbMetadata.vpaidTimeout.started >= 0) {
-            this.VPAID_AD_STARTED_TIMEOUT = pbMetadata.vpaidTimeout.started * 1000;
-          }
-
-          if (_.isNumber(pbMetadata.vpaidTimeout.stopped) && pbMetadata.vpaidTimeout.stopped >= 0) {
-            this.VPAID_AD_STOPPED_TIMEOUT = pbMetadata.vpaidTimeout.stopped * 1000;
-          }
+        if (_.isNumber(pbMetadata.vpaidTimeout.stopped) && pbMetadata.vpaidTimeout.stopped >= 0) {
+          this.VPAID_AD_STOPPED_TIMEOUT = pbMetadata.vpaidTimeout.stopped * 1000;
         }
       }
 
@@ -833,17 +823,11 @@ OO.Ads.manager(function(_, $) {
      */
     var loadAd = _.bind(function(amcAd) {
       var loadedAds = false;
-      var override = false;
       var ad = amcAd.ad;
       this.amc.notifyPodStarted(amcAd.id, 1);
-      if (this.adURLOverride) {
-        override = true;
-        ad.tag_url = this.adURLOverride;
-      }
 
       this.currentAdBeingLoaded = ad;
-      var url = typeof ad.url !== 'undefined' && !override ? ad.url : ad.tag_url;
-      this.loadUrl(url);
+      this.loadUrl(ad.tag_url);
       loadedAds = true;
       return loadedAds;
     }, this);
@@ -899,7 +883,7 @@ OO.Ads.manager(function(_, $) {
     };
 
     /**
-     *
+     * TODO: out of date
      * This is required by the Ad Manager Controller but for Vast ads nothing is done here.
      * @returns The array of the new timeline to merge into the controller timeline but Vast Manager doesn't use this
      * function since we add the Ads one by one, so we just return null so it is ignored by the AMC.
@@ -922,11 +906,22 @@ OO.Ads.manager(function(_, $) {
           };
 
           if (adMetadata.position_type == 't') {
-            adData.position = adMetadata.time/1000;
+            //Movie metadata uses time, page level metadata uses position
+            if (_.isFinite(+adMetadata.time)) {
+              adData.position = adMetadata.time / 1000;
+            }
           } else if (adMetadata.position_type == 'p') {
-            //TODO
-            //adData.position =
+            if (_.isFinite(+adMetadata.position)) {
+              adData.position = +adMetadata.position / 100 * this.mainContentDuration;
+            }
           }
+          adMetadata.position = adData.position;
+
+          //Movie metadata uses url, page level metadata uses tag_url
+          if (!adMetadata.tag_url) {
+            adMetadata.tag_url = adMetadata.url;
+          }
+
           var amcAd = new this.amc.Ad(adData);
           timeline.push(amcAd);
         }
@@ -1890,7 +1885,7 @@ OO.Ads.manager(function(_, $) {
       vastAdUnit.data.type = this.amc.ADTYPE.LINEAR_VIDEO;
       vastAdUnit.adPodIndex = params.adPodIndex ? params.adPodIndex : 1;
       vastAdUnit.adPodLength = params.adPodLength ? params.adPodLength : 1;
-      vastAdUnit.positionSeconds = adLoaded.time/1000;
+      vastAdUnit.positionSeconds = adLoaded.position;
       vastAdUnit.repeatAfter = adLoaded.repeatAfter ? adLoaded.repeatAfter : null;
 
       // Save the stream data for use by VideoController
@@ -1941,7 +1936,7 @@ OO.Ads.manager(function(_, $) {
       vastAdUnit.data.type = this.amc.ADTYPE.NONLINEAR_OVERLAY;
       vastAdUnit.adPodIndex = params.adPodIndex ? params.adPodIndex : 1;
       vastAdUnit.adPodLength = params.adPodLength ? params.adPodLength : 1;
-      vastAdUnit.positionSeconds = adLoaded.time/1000;
+      vastAdUnit.positionSeconds = adLoaded.position;
       vastAdUnit.repeatAfter = adLoaded.repeatAfter ? adLoaded.repeatAfter : null;
 
       return vastAdUnit;
@@ -2647,21 +2642,21 @@ OO.Ads.manager(function(_, $) {
       if (adBreak.timeOffset) {
         // case: "start"
         if (/^start$/.test(adBreak.timeOffset)) {
-          adObject.time = 0;
+          adObject.position = 0;
         }
         // case: "end"
         else if (/^end$/.test(adBreak.timeOffset)) {
-          adObject.time = (this.amc.movieDuration + 1) * 1000;
+          adObject.position = (this.amc.movieDuration + 1);
 
         }
         // case: hh:mm:ss.mmm | hh:mm:ss
         else if (/^\d{2}:\d{2}:\d{2}\.000$|^\d{2}:\d{2}:\d{2}$/.test(adBreak.timeOffset)) {
-          adObject.time = adManagerUtils.convertTimeStampToMilliseconds(adBreak.timeOffset, this.amc.movieDuration);
+          adObject.position = adManagerUtils.convertTimeStampToMilliseconds(adBreak.timeOffset, this.amc.movieDuration) / 1000;
         }
         // case: [0, 100]%
         else if (/^\d{1,3}%$/.test(adBreak.timeOffset)) {
           // TODO: test percentage > 100
-          adObject.time = adManagerUtils.convertPercentToMilliseconds(adBreak.timeOffset);
+          adObject.position = adManagerUtils.convertPercentToMilliseconds(adBreak.timeOffset) / 1000;
         }
         else {
           _tryRaiseAdError("VAST, VMAP: No Matching 'timeOffset' Attribute format");
@@ -2812,7 +2807,7 @@ OO.Ads.manager(function(_, $) {
         adPodLength: adPodLength ? adPodLength : 1,
         data: data,
         fallbackAd: null,
-        positionSeconds: adLoaded.time / 1000,
+        positionSeconds: adLoaded.position,
         adParams: adParams,
         streams: {'mp4': ''},
         type: AD_TYPE.INLINE,

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -909,6 +909,8 @@ OO.Ads.manager(function(_, $) {
             //Movie metadata uses time, page level metadata uses position
             if (_.isFinite(+adMetadata.time)) {
               adData.position = adMetadata.time / 1000;
+            } else if (_.isFinite(+adMetadata.position)) {
+              adData.position = adMetadata.position / 1000;
             }
           } else if (adMetadata.position_type == 'p') {
             if (_.isFinite(+adMetadata.position)) {

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -925,7 +925,7 @@ OO.Ads.manager(function(_, $) {
           }
 
           //Only add to timeline if the tag url and position are valid
-          if (adMetadata.tag_url && _.isFinite(adMetadata.position)) {
+          if (_.isString(adMetadata.tag_url) && _isValidPosition(adMetadata.position)) {
             var amcAd = new this.amc.Ad(adData);
             timeline.push(amcAd);
           }

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -907,13 +907,13 @@ OO.Ads.manager(function(_, $) {
 
           if (adMetadata.position_type == 't') {
             //Movie metadata uses time, page level metadata uses position
-            if (_.isFinite(+adMetadata.time)) {
-              adData.position = adMetadata.time / 1000;
-            } else if (_.isFinite(+adMetadata.position)) {
-              adData.position = adMetadata.position / 1000;
+            if (_isValidPosition(adMetadata.time)) {
+              adData.position = +adMetadata.time / 1000;
+            } else if (_isValidPosition(adMetadata.position)) {
+              adData.position = +adMetadata.position / 1000;
             }
           } else if (adMetadata.position_type == 'p') {
-            if (_.isFinite(+adMetadata.position)) {
+            if (_isValidPosition(adMetadata.position)) {
               adData.position = +adMetadata.position / 100 * this.mainContentDuration;
             }
           }
@@ -924,12 +924,28 @@ OO.Ads.manager(function(_, $) {
             adMetadata.tag_url = adMetadata.url;
           }
 
-          var amcAd = new this.amc.Ad(adData);
-          timeline.push(amcAd);
+          //Only add to timeline if the tag url and position are valid
+          if (adMetadata.tag_url && _.isFinite(adMetadata.position)) {
+            var amcAd = new this.amc.Ad(adData);
+            timeline.push(amcAd);
+          }
         }
       }
       return timeline;
     };
+
+    /**
+     * Checks to see if the provided position metadata is valid.
+     * @private
+     * @method Vast#_isValidPosition
+     * @param {*} position The position metadata to check
+     * @returns {boolean} True if the position is valid, false otherwise
+     */
+    var _isValidPosition = _.bind(function(position) {
+      //Unary + returns 1 for true and 0 for false and null
+      //To avoid this, we check to see if position is a number or a string
+      return (typeof position === 'string' || typeof position === 'number') && _.isFinite(+position);
+    }, this);
 
     /**
      * Called when the ad starts playback.

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -1929,6 +1929,127 @@ describe('ad_manager_vast', function() {
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });
 
+  it('Vast Ad Manager: Can add multiple position type \'t\' ads with page level settings', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": 10000
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": 20000
+        }
+      ]
+    }, {}, content);
+    amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
+    expect(amc.timeline.length).to.be(2);
+    expect(amc.timeline[0].ad.position).to.be(10);
+    expect(amc.timeline[1].ad.position).to.be(20);
+    vastAdManager.playAd(amc.timeline[0]);
+    expect(vastAdManager.vastUrl).to.be("http://blahblah");
+  });
+
+  it('Vast Ad Manager: Can add multiple position type \'p\' ads with page level settings', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": 25
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": 50
+        }
+      ]
+    }, {}, content);
+    amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
+    expect(amc.timeline.length).to.be(2);
+    expect(amc.timeline[0].ad.position).to.be(30);
+    expect(amc.timeline[1].ad.position).to.be(60);
+    vastAdManager.playAd(amc.timeline[0]);
+    expect(vastAdManager.vastUrl).to.be("http://blahblah");
+  });
+
+  it('Vast Ad Manager: Can add multiple mixed position type ads with page level settings', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": 25
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": 50000
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": 0
+        }
+      ]
+    }, {}, content);
+    amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
+    expect(amc.timeline.length).to.be(3);
+    expect(amc.timeline[0].ad.position).to.be(30);
+    expect(amc.timeline[1].ad.position).to.be(50);
+    //Timeline is not sorted at this point
+    expect(amc.timeline[2].ad.position).to.be(0);
+    vastAdManager.playAd(amc.timeline[2]);
+    expect(vastAdManager.vastUrl).to.be("http://blahblah");
+  });
+
   it('Vast Ad Manager: Should ignore page level settings with null positions', function() {
     var embed_code = "embed_code";
     var vast_ad = {

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -1944,7 +1944,6 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad],
       duration: 120000
     };
-    debugger;
     vastAdManager.initialize(amc);
     vastAdManager.loadMetadata({
       "all_ads": [
@@ -1978,7 +1977,6 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad],
       duration: 120000
     };
-    debugger;
     vastAdManager.initialize(amc);
     vastAdManager.loadMetadata({
       "all_ads": [
@@ -2010,7 +2008,6 @@ describe('ad_manager_vast', function() {
       ads: [vast_ad],
       duration: 120000
     };
-    debugger;
     vastAdManager.initialize(amc);
     vastAdManager.loadMetadata({
       "all_ads": [

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -92,7 +92,9 @@ describe('ad_manager_vast', function() {
       frequency: 2,
       ad_set_code: "ad_set_code",
       time:0,
-      position_type:"t"
+      position_type:"t",
+      position:0,
+      url: "http://blahurl"
     };
     var content = {
       embed_code: embed_code,
@@ -112,7 +114,8 @@ describe('ad_manager_vast', function() {
           ad_set_code: "ad_set_code",
           time:0,
           position_type:"t",
-          position:0
+          position:0,
+          url: "http://blahurl"
         },
         content = {
           embed_code: embed_code,
@@ -269,7 +272,8 @@ describe('ad_manager_vast', function() {
       frequency: 2,
       ad_set_code: "ad_set_code",
       time:0,
-      position_type:"t"
+      position_type:"t",
+      url:"http://blahurl"
     };
     var content = {
       embed_code: embed_code,
@@ -293,7 +297,8 @@ describe('ad_manager_vast', function() {
       frequency: 2,
       ad_set_code: "ad_set_code",
       time:10000,
-      position_type:"t"
+      position_type:"t",
+      url:"http://blahurl"
     };
     var content = {
       embed_code: embed_code,
@@ -317,7 +322,8 @@ describe('ad_manager_vast', function() {
       frequency: 2,
       ad_set_code: "ad_set_code",
       time:0,
-      position_type:"t"
+      position_type:"t",
+      url:"0.mp4"
     };
     var vast_ad_mid = {
       type: "vast",
@@ -1815,13 +1821,43 @@ describe('ad_manager_vast', function() {
       duration: 120000
     };
     vastAdManager.initialize(amc);
-    debugger;
     vastAdManager.loadMetadata({
       "all_ads": [
         {
           "tag_url": "http://blahblah",
           "position_type": "t",
           "position": 10000
+        }
+      ]
+    }, {}, content);
+    amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
+    expect(amc.timeline[0].ad.position).to.be(10);
+    vastAdManager.playAd(amc.timeline[0]);
+    expect(vastAdManager.vastUrl).to.be("http://blahblah");
+  });
+
+  it('Vast Ad Manager: Should use page level settings with position_type t with string position', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": "10000"
         }
       ]
     }, {}, content);
@@ -1860,6 +1896,157 @@ describe('ad_manager_vast', function() {
     expect(amc.timeline[0].ad.position).to.be(60);
     vastAdManager.playAd(amc.timeline[0]);
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
+  });
+
+  it('Vast Ad Manager: Should use page level settings with position_type p with string position', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": "50"
+        }
+      ]
+    }, {}, content);
+    amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
+    expect(amc.timeline[0].ad.position).to.be(60);
+    vastAdManager.playAd(amc.timeline[0]);
+    expect(vastAdManager.vastUrl).to.be("http://blahblah");
+  });
+
+  it('Vast Ad Manager: Should ignore page level settings with null positions', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    debugger;
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": null
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": null
+        }
+      ]
+    }, {}, content);
+    expect(amc.timeline.length).to.be(0);
+  });
+
+  it('Vast Ad Manager: Should ignore page level settings with undefined positions', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    debugger;
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t"
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p"
+        }
+      ]
+    }, {}, content);
+    expect(amc.timeline.length).to.be(0);
+  });
+
+  it('Vast Ad Manager: Should ignore page level settings with non-string/non-number positions', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    debugger;
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": {}
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": function(){}
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": true
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": false
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": NaN
+        },
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": "NaN"
+        }
+      ]
+    }, {}, content);
+    expect(amc.timeline.length).to.be(0);
   });
 
   it('VPAID 2.0: Should use VPAID recovery timeout overrides', function() {

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -111,7 +111,8 @@ describe('ad_manager_vast', function() {
           frequency: 2,
           ad_set_code: "ad_set_code",
           time:0,
-          position_type:"t"
+          position_type:"t",
+          position:0
         },
         content = {
           embed_code: embed_code,
@@ -1798,7 +1799,7 @@ describe('ad_manager_vast', function() {
     expect(amc.timeline.length).to.be(0);
   });
 
-  it('Vast 3.0: Should use ad tag url override', function() {
+  it('Vast Ad Manager: Should use page level settings with position_type t', function() {
     var embed_code = "embed_code";
     var vast_ad = {
       type: "vast",
@@ -1810,11 +1811,53 @@ describe('ad_manager_vast', function() {
     };
     var content = {
       embed_code: embed_code,
-      ads: [vast_ad]
+      ads: [vast_ad],
+      duration: 120000
     };
     vastAdManager.initialize(amc);
-    vastAdManager.loadMetadata({"tagUrl": "http://blahblah"}, {}, content);
+    debugger;
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "t",
+          "position": 10000
+        }
+      ]
+    }, {}, content);
     amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
+    expect(amc.timeline[0].ad.position).to.be(10);
+    vastAdManager.playAd(amc.timeline[0]);
+    expect(vastAdManager.vastUrl).to.be("http://blahblah");
+  });
+
+  it('Vast Ad Manager: Should use page level settings with position_type p', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": "http://blahblah",
+          "position_type": "p",
+          "position": 50
+        }
+      ]
+    }, {}, content);
+    amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
+    expect(amc.timeline[0].ad.position).to.be(60);
     vastAdManager.playAd(amc.timeline[0]);
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -2050,6 +2050,63 @@ describe('ad_manager_vast', function() {
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });
 
+  it('Vast Ad Manager: Should ignore page level settings with non-string tag_urls', function() {
+    var embed_code = "embed_code";
+    var vast_ad = {
+      type: "vast",
+      first_shown: 0,
+      frequency: 2,
+      ad_set_code: "ad_set_code",
+      time:0,
+      position_type:"t"
+    };
+    var content = {
+      embed_code: embed_code,
+      ads: [vast_ad],
+      duration: 120000
+    };
+    vastAdManager.initialize(amc);
+    vastAdManager.loadMetadata({
+      "all_ads": [
+        {
+          "tag_url": null,
+          "position_type": "t",
+          "position": 0
+        },
+        {
+          "position_type": "p",
+          "position": 0
+        },
+        {
+          "tag_url": {},
+          "position_type": "t",
+          "position": 0
+        },
+        {
+          "tag_url": function(){},
+          "position_type": "t",
+          "position": 0
+        },
+        {
+          "tag_url": true,
+          "position_type": "t",
+          "position": 0
+        },
+        {
+          "tag_url": false,
+          "position_type": "t",
+          "position": 0
+        },
+        {
+          "tag_url": 12345,
+          "position_type": "t",
+          "position": 0
+        }
+      ]
+    }, {}, content);
+    expect(amc.timeline.length).to.be(0);
+  });
+
   it('Vast Ad Manager: Should ignore page level settings with null positions', function() {
     var embed_code = "embed_code";
     var vast_ad = {


### PR DESCRIPTION
-Vast page level settings
Added support for all_ads array of ad objects. An ad object should have a tag_url, position_type, and position. This was done to match IMA page level ad support: http://help.ooyala.com/video-platform/concepts/pbv4_ads_dev_google_ima_parameters.html