### PR TITLE
[PBI-2051] Fix issue where closing overlay ad resets playhead to 0

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1473,7 +1473,7 @@ require("../html5-common/js/utils/utils.js");
           case eventType.USER_CLOSE:
           case eventType.SKIPPED:
           case eventType.COMPLETE:
-            if (this.videoControllerWrapper)
+            if (this.videoControllerWrapper && (ad && ad.isLinear()))
             {
               _stopTimeUpdater();
               //IMA provides values which can result in negative current times or current times which are greater than duration.

--- a/test/unit-test-helpers/mock_ima.js
+++ b/test/unit-test-helpers/mock_ima.js
@@ -167,7 +167,7 @@ google =
       {
         ALL_ADS_COMPLETED : "allAdsCompleted",
         COMPLETE : "complete",
-        SKIPPED : "skipped",
+        SKIPPED : "skip",
         FIRST_QUARTILE : "firstQuartile",
         LOADED : "loaded",
         MIDPOINT : "midpoint",

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -717,6 +717,7 @@ describe('ad_manager_ima', function()
 
   it('AMC Integration, IMA Event: IMA COMPLETE event notifies amc of linear ad end for a linear ad', function()
   {
+    var raiseTimeUpdateCalled = 0;
     var notified = false;
     var adId = -1;
     initAndPlay(true, vci);
@@ -730,11 +731,18 @@ describe('ad_manager_ima', function()
       id : "ad_1000",
       ad : {}
     });
+    ima.videoControllerWrapper.raiseTimeUpdate = function() {
+      raiseTimeUpdateCalled++;
+    };
+
     var am = google.ima.adManagerInstance;
     am.publishEvent(google.ima.AdEvent.Type.STARTED);
     am.publishEvent(google.ima.AdEvent.Type.COMPLETE);
     expect(notified).to.be(true);
     expect(adId).to.be("ad_1000");
+
+    // time update should only be raised twice: once for STARTED and and another COMPLETE
+    expect(raiseTimeUpdateCalled).to.be(2);
   });
 
   it('AMC Integration, IMA Event: IMA USER_CLOSE event notifies amc of linear ad end for a linear ad', function()
@@ -785,6 +793,7 @@ describe('ad_manager_ima', function()
     {
       ad : {}
     });
+
     var am = google.ima.adManagerInstance;
     am.publishEvent(google.ima.AdEvent.Type.STARTED);
     //mock ima has a default ad pod size of 1 (returned via getTotalAds)
@@ -831,6 +840,7 @@ describe('ad_manager_ima', function()
 
   it('AMC Integration, IMA Event: IMA COMPLETE event (non-linear ad) notifies amc of non-linear ad end', function()
   {
+    var raiseTimeUpdateCalled = 0;
     var notified = false;
     google.ima.linearAds = false;
     initAndPlay(true, vci);
@@ -842,9 +852,16 @@ describe('ad_manager_ima', function()
     {
       ad : {}
     });
+    ima.videoControllerWrapper.raiseTimeUpdate = function() {
+      raiseTimeUpdateCalled++;
+    };
+
     var am = google.ima.adManagerInstance;
     am.publishEvent(google.ima.AdEvent.Type.STARTED);
     am.publishEvent(google.ima.AdEvent.Type.COMPLETE);
+
+    // time update should only be raised once for STARTED, but not COMPLETE
+    expect(raiseTimeUpdateCalled).to.be(1);
     expect(notified).to.be(true);
   });
 


### PR DESCRIPTION
- only update play head on COMPLETE (IMA event) if the ad linear