### PR TITLE
[player-58]

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -146,6 +146,7 @@ require("../html5-common/js/utils/utils.js");
         this.adPlaybackStarted = false;
         this.vcPlayRequested = false;
         this.savedVolume = -1;
+        this.showAdControls = false;
         this.useGoogleAdUI = false;
         this.useGoogleCountdown = false;
         this.useInsecureVpaidMode = false;
@@ -252,6 +253,12 @@ require("../html5-common/js/utils/utils.js");
         if (metadata.hasOwnProperty("additionalAdTagParameters"))
         {
           this.additionalAdTagParameters = metadata.additionalAdTagParameters;
+        }
+
+        this.showAdControls = false;
+        if (metadata.hasOwnProperty("showAdControls"))
+        {
+          this.showAdControls = metadata.showAdControls;
         }
 
         this.useGoogleAdUI = false;
@@ -1442,7 +1449,7 @@ require("../html5-common/js/utils/utils.js");
                 this.savedVolume = -1;
               }
               //Since IMA handles its own UI, we want the video player to hide its UI elements
-              _amc.hidePlayerUi();
+              _amc.hidePlayerUi(this.showAdControls, false);
             }
             else
             {

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -375,10 +375,42 @@ describe('ad_manager_ima', function()
   it('Play ad: Requests the AMC to hide the player UI', function()
   {
     var notified = false;
-    amc.hidePlayerUi = function() {
+    amc.hidePlayerUi = function(showAdControls, showAdMarquee) {
+      expect(showAdControls).to.be(false);
+      expect(showAdMarquee).to.be(false);
       notified = true;
     };
     initAndPlay(true, vci);
+    ima.playAd(amc.timeline[0]);
+    var am = google.ima.adManagerInstance;
+    am.publishEvent(google.ima.AdEvent.Type.STARTED);
+    expect(notified).to.be(true);
+  });
+
+  it('Play ad: Metadata setting can choose to show the ad controls while hiding player UI', function()
+  {
+    var notified = false;
+    amc.hidePlayerUi = function(showAdControls, showAdMarquee) {
+      expect(showAdControls).to.be(true);
+      expect(showAdMarquee).to.be(false);
+      notified = true;
+    };
+    ima.initialize(amc, playerId);
+    ima.registerUi();
+    var ad =
+    {
+      tag_url : "https://blah",
+      position_type : AD_RULES_POSITION_TYPE
+    };
+    var content =
+    {
+      all_ads : [ad],
+      showAdControls: true
+    };
+    ima.loadMetadata(content, {}, {});
+    amc.timeline = ima.buildTimeline();
+    createVideoWrapper(vci);
+    play();
     ima.playAd(amc.timeline[0]);
     var am = google.ima.adManagerInstance;
     am.publishEvent(google.ima.AdEvent.Type.STARTED);


### PR DESCRIPTION
-added support for page level setting “showAdControls” to control whether or not the ad controls appear for IMA ads