### PR TITLE
PSDK-688 : stop the placeholder ad right away if the SDK is not loaded

### DIFF
--- a/js/pulse.js
+++ b/js/pulse.js
@@ -429,6 +429,13 @@
              * @param v4ad
              */
             this.playAd = function(v4ad) {
+
+                //If the SDK is not loaded, tell the AMC our placeholder ad is finished
+                if(!adModuleJsReady){
+                    amc.notifyPodEnded(v4ad.id);
+                    return;
+                }
+
                 podStarted = v4ad.id;
                 isInAdMode = true;
                 this._isInPlayAd = true;


### PR DESCRIPTION
@pilievOoyala @aeng7 Can you guys check if this is okay? What we do here is just check if the SDK is loaded or not when our placeholder preroll ad should play. If it's not we tell the AMC it's ended so the player can move on. Let me know if you don't think that's the correct way of doing it.

Thanks!