### PR TITLE
PSDK 472: Overlay support for the Pulse plugin

### DIFF
--- a/js/pulse.js
+++ b/js/pulse.js
@@ -459,17 +459,20 @@
             }
 
 
+            //When the overlay shoule be removed
             function onOverlayFinished(){
                 clearTimeout(overlayTimer);
                 amc.notifyNonlinearAdEnded(currentOverlayAd.id);
                 currentOverlayAd = null;
             }
 
+            //
             function startOverlayCountdown(){
                 lastOverlayAdStart = Date.now();
                 overlayTimer = setTimeout(onOverlayFinished, overlayTimeLeftMillis);
             }
 
+            //Called when the overlay is displayed
             function onOverlayShown(){
                 if(currentOverlayAd){
                     overlayTimeLeftMillis = currentOverlayAd.ad.getDuration() * 1000;
@@ -478,6 +481,7 @@
                 }
             }
 
+            //Save the current display time of the overlay so it can be resumed later
             function overlayPause(){
                 if(currentOverlayAd){
                     overlayTimeLeftMillis = overlayTimeLeftMillis - (Date.now() - lastOverlayAdStart);
@@ -490,6 +494,10 @@
              * @param v4ad
              */
             this.playAd = function(v4ad) {
+
+                if (v4ad === null){
+                    return;
+                }
                 //If the SDK is not loaded, tell the AMC our placeholder ad is finished
                 if(!adModuleJsReady){
                     amc.notifyPodEnded(v4ad.id);
@@ -689,6 +697,10 @@
                 return false;
             };
 
+            /**
+             * Called by the Pulse SDK when an overlay should shown
+             * @param pulseOverlayAd
+             */
             this.showOverlayAd = function (pulseOverlayAd) {
                 if (currentOverlayAd){
                     onOverlayFinished();
@@ -702,6 +714,10 @@
                     [pulseOverlayAd.getResourceURL()]);
             };
 
+            /**
+             * Called by the Pulse SDK to show a pause ad.
+             * @param pulsePauseAd
+             */
             this.showPauseAd = function (pulsePauseAd) {
                 //console.error("Showing pause ad", pulsePauseAd);
                 //this._currentPauseAd = pulsePauseAd;
@@ -719,7 +735,6 @@
 
             this.hideOverlay = function (ad) {
                 overlayTimeLeftMillis = overlayTimeLeftMillis - (Date.now() - lastOverlayAdStart);
-                //hide overlay fixme
             };
 
             this.illegalOperationOccurred = function(msg) {
@@ -752,9 +767,9 @@
 
             var _onPlayStarted = function() {
                 //Hide a pause ad is there was any
-                if(this._currentPauseAd){
-                    amc.notifyNonlinearAdEnded(this_)
-                }
+                //if(this._currentPauseAd){
+                //    amc.notifyNonlinearAdEnded(this_)
+                //}
                 if(adPlayer)
                     adPlayer.contentStarted();
             };

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -481,12 +481,18 @@
                 }
             }
 
+            function overlayPause(){
+                if(currentOverlayAd){
+                    overlayTimeLeftMillis = overlayTimeLeftMillis - (Date.now() - lastOverlayAdStart);
+                    clearTimeout(overlayTimer);
+                }
+            }
+
             /**
              * Mandatory method. Called by the AMF when an ad play has been requested
              * @param v4ad
              */
             this.playAd = function(v4ad) {
-
 
                 console.error("play ad", v4ad);
                 //If the SDK is not loaded, tell the AMC our placeholder ad is finished
@@ -494,10 +500,6 @@
                     amc.notifyPodEnded(v4ad.id);
                     return;
                 }
-
-
-
-
 
                 if(v4ad.adType === amc.ADTYPE.NONLINEAR_OVERLAY){
                     console.error("play overlay");
@@ -521,6 +523,7 @@
                 isInAdMode = true;
                 podStarted = v4ad.id;
                 this._isInPlayAd = true;
+                overlayPause();
 
                 if(adPlayer){
                     adPlayer.contentPaused();
@@ -626,27 +629,6 @@
                 contentPaused = true;
                 if(adPlayer){
                     adPlayer.contentPaused();
-
-                    //CSS changes
-                    //oo-interactive container
-                    //pos absolute
-                    // left bottom 0
-                    //width 100
-                    //height 100
-                    //background black
-
-                    //oo-control-bar
-                    // absolute
-                    // bottom 0
-
-
-                    //oo-ad-overlay-image
-                    //margin left right auto
-                    // bottom 0
-                    //width auto
-                    //height 100
-                    //pos absolute
-
                 }
             };
 
@@ -670,13 +652,13 @@
                     podStarted = id;
                 }
                 amc.notifyPodStarted(podStarted, adCount);
-            }
+            };
 
             this.notifyAdPodEnded = function(){
                 var podEndedId = podStarted;
                 podStarted = null;
                 amc.notifyPodEnded(podEndedId);
-            }
+            };
 
             this.startContentPlayback = function() {
                 isWaitingForPrerolls = false;

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -913,15 +913,9 @@
                     -1, isFullscreen);
             };
 
+            //Will be used when overlay events are added
             var _onOverlayShown = function (event, metadata) {
-                //amc.notifyNonlinearAdStarted(1);
-                var adData = {
-                    //position_type: NON_AD_RULES_POSITION_TYPE,
-                    forced_ad_type: amc.ADTYPE.NONLINEAR_OVERLAY
-                };
-
-                amc.sendURLToLoadAndPlayNonLinearAd("test", "id",metadata.ad.getResourceURL());
-                //amc.forceAdToPlay(this.name, adData, amc.ADTYPE.NONLINEAR_OVERLAY);
+                //amc.sendURLToLoadAndPlayNonLinearAd("test", "id",metadata.ad.getResourceURL());
             };
         };
         return new PulseAdManager();

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -88,7 +88,8 @@
                 //Set the CSS overlay so it's responsive
 
                 style = document.createElement('style');
-                var css = '.oo-ad-overlay-image { width:100% !important}';
+                var css = '.oo-ad-overlay-image { width:100% !important}' +
+                    ' .oo-ad-overlay {  margin:auto !important}';
 
                 style.type = 'text/css';
                 if (style.styleSheet) {
@@ -473,11 +474,11 @@
             }
 
             function onOverlayShown(){
-                //if(currentOverlayAd){
-                //    overlayTimeLeftMillis = currentOverlayAd.ad.getDuration() * 1000;
-                //    adPlayer.overlayAdShown(currentOverlayAd.ad);
-                //    startOverlayCountdown();
-                //}
+                if(currentOverlayAd){
+                    overlayTimeLeftMillis = currentOverlayAd.ad.getDuration() * 1000;
+                    adPlayer.overlayAdShown(currentOverlayAd.ad);
+                    startOverlayCountdown();
+                }
             }
 
             /**
@@ -486,15 +487,17 @@
              */
             this.playAd = function(v4ad) {
 
+
+                console.error("play ad", v4ad);
                 //If the SDK is not loaded, tell the AMC our placeholder ad is finished
                 if(!adModuleJsReady){
                     amc.notifyPodEnded(v4ad.id);
                     return;
                 }
 
-                podStarted = v4ad.id;
-                isInAdMode = true;
-                this._isInPlayAd = true;
+
+
+
 
                 if(v4ad.adType === amc.ADTYPE.NONLINEAR_OVERLAY){
                     console.error("play overlay");
@@ -514,6 +517,10 @@
 
                     return;
                 }
+
+                isInAdMode = true;
+                podStarted = v4ad.id;
+                this._isInPlayAd = true;
 
                 if(adPlayer){
                     adPlayer.contentPaused();
@@ -582,8 +589,6 @@
              */
             this.playerClicked = function(amcAd, showPage) {
                 if(this._currentAd) {
-
-
                     var clickThroughURL = this._currentAd.getClickthroughURL();
                     if (clickThroughURL) {
                         this.openClickThrough(clickThroughURL);
@@ -660,6 +665,7 @@
 
 
             this.notifyAdPodStarted = function(id, adCount){
+                console.error("ad pod started",id,podStarted);
                 if(!podStarted) {
                     podStarted = id;
                 }
@@ -721,16 +727,18 @@
             };
 
             this.showPauseAd = function (pulsePauseAd) {
-                console.error("Showing pause ad",pulsePauseAd);
+                console.error("Showing pause ad", pulsePauseAd);
                 this._currentPauseAd = pulsePauseAd;
 
-                amc.forceAdToPlay(this.name, pulsePauseAd,amc.ADTYPE.NONLINEAR_OVERLAY, [pulsePauseAd.getResourceURL()]);
+                amc.forceAdToPlay(this.name, pulsePauseAd, amc.ADTYPE.NONLINEAR_OVERLAY, [pulsePauseAd.getResourceURL()]);
             };
 
             this.showOverlay = function () {
                 console.error("Resuming v4 overlay");
-                amc.sendURLToLoadAndPlayNonLinearAd(currentOverlayAd.ad, currentOverlayAd.id, currentOverlayAd.ad.getResourceURL());
-                startOverlayCountdown();
+                if (currentOverlayAd){
+                    amc.sendURLToLoadAndPlayNonLinearAd(currentOverlayAd.ad, currentOverlayAd.id, currentOverlayAd.ad.getResourceURL());
+                    startOverlayCountdown();
+                }
             };
 
             this.hideOverlay = function (ad) {
@@ -752,7 +760,8 @@
                     adPlayer.adClickThroughOpened();
                 }
 
-            }
+            };
+
             var playPlaceholder = _.bind(function () {
                 var streams = {};
                 streams[OO.VIDEO.ENCODING.PULSE] = "";
@@ -817,13 +826,6 @@
                                 VPAIDViewMode: OO.Pulse.AdPlayer.Settings.VPAIDViewMode.NORMAL,
                                 renderingMode: preferredRenderingMode || renderingMode
                             }, this.sharedVideoElement);
-                        //var overlayContainer = document.createElement('div');
-                        //overlayContainer.style.width = "100%";
-                        //overlayContainer.style.height = "100%";
-                        //var parent = amc.ui.playerSkinPluginsElement ? amc.ui.playerSkinPluginsElement[0] : amc.ui.pluginsElement[0];
-                        //parent.appendChild(overlayContainer);
-                        //
-                        //adPlayer.setOverlayDiv(overlayContainer);
 
                         //We register all the event listeners we will need
                         adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.AD_BREAK_FINISHED, _.bind(_onAdBreakFinished,this));
@@ -882,7 +884,6 @@
                     -1, isFullscreen);
                 this._currentAdBreak = eventData.adBreak;
                 this.notifyAdPodStarted(this._adBreakId,this._currentAdBreak.getPlayableAdsTotal());
-
             };
 
             var _onAdClicked = function (event,eventData) {
@@ -890,17 +891,17 @@
             };
             var _onAdPaused = function(event,metadata){
                 this.videoControllerWrapper.raisePauseEvent();
-            }
+            };
 
             var _onAdPlaying = function(event,metadata){
                 this.videoControllerWrapper.raisePlayingEvent();
-            }
+            };
 
             var _onSessionStarted = function(event, metadata) {
                 if(pluginCallbacks && pluginCallbacks.onSessionCreated) {
                     pluginCallbacks.onSessionCreated(session);
                 }
-            }
+            };
 
             var _onAdTimeUpdate = function(event, eventData) {
 
@@ -947,8 +948,8 @@
 
                 amc.sendURLToLoadAndPlayNonLinearAd("test", "id",metadata.ad.getResourceURL());
                 //amc.forceAdToPlay(this.name, adData, amc.ADTYPE.NONLINEAR_OVERLAY);
-            }
-        }
+            };
+        };
         return new PulseAdManager();
     });
 

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -493,8 +493,6 @@
              * @param v4ad
              */
             this.playAd = function(v4ad) {
-
-                console.error("play ad", v4ad);
                 //If the SDK is not loaded, tell the AMC our placeholder ad is finished
                 if(!adModuleJsReady){
                     amc.notifyPodEnded(v4ad.id);
@@ -502,7 +500,6 @@
                 }
 
                 if(v4ad.adType === amc.ADTYPE.NONLINEAR_OVERLAY){
-                    console.error("play overlay");
                     if(contentPaused){
                         currentPauseAd = v4ad;
                     } else {
@@ -511,12 +508,10 @@
 
                     amc.sendURLToLoadAndPlayNonLinearAd(v4ad.ad, v4ad.id, v4ad.ad.getResourceURL());
 
-                    //Assume the ad was loaded FIXME
+                    //Assume the ad was loaded
                     if(!contentPaused){
                         onOverlayShown();
                     }
-
-
                     return;
                 }
 
@@ -599,7 +594,7 @@
                 } else if (this._currentOverlayAd){
                     adPlayer.overlayAdClicked(this._currentOverlayAd);
                 } else if (this._currentPauseAd){
-                    console.error("Pause ad clicked");
+                    //TODO
                 }
             };
 
@@ -647,7 +642,6 @@
 
 
             this.notifyAdPodStarted = function(id, adCount){
-                console.error("ad pod started",id,podStarted);
                 if(!podStarted) {
                     podStarted = id;
                 }
@@ -699,7 +693,10 @@
             };
 
             this.showOverlayAd = function (pulseOverlayAd) {
-                console.error("Showing overlay",pulseOverlayAd);
+                if (currentOverlayAd){
+                    onOverlayFinished();
+                }
+
                 this._currentOverlayAd = pulseOverlayAd;
 
                 amc.forceAdToPlay(this.name,
@@ -709,14 +706,14 @@
             };
 
             this.showPauseAd = function (pulsePauseAd) {
-                console.error("Showing pause ad", pulsePauseAd);
-                this._currentPauseAd = pulsePauseAd;
-
-                amc.forceAdToPlay(this.name, pulsePauseAd, amc.ADTYPE.NONLINEAR_OVERLAY, [pulsePauseAd.getResourceURL()]);
+                //console.error("Showing pause ad", pulsePauseAd);
+                //this._currentPauseAd = pulsePauseAd;
+                //
+                //amc.forceAdToPlay(this.name, pulsePauseAd, amc.ADTYPE.NONLINEAR_OVERLAY, [pulsePauseAd.getResourceURL()]);
             };
 
+            //This method is called by the V4 AMF
             this.showOverlay = function () {
-                console.error("Resuming v4 overlay");
                 if (currentOverlayAd){
                     amc.sendURLToLoadAndPlayNonLinearAd(currentOverlayAd.ad, currentOverlayAd.id, currentOverlayAd.ad.getResourceURL());
                     startOverlayCountdown();
@@ -724,7 +721,6 @@
             };
 
             this.hideOverlay = function (ad) {
-                console.error("hide v4 overlay",ad);
                 overlayTimeLeftMillis = overlayTimeLeftMillis - (Date.now() - lastOverlayAdStart);
                 //hide overlay fixme
             };

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -57,8 +57,6 @@
              */
             this.initialize = function(adManagerController, playerId) {
                 amc = adManagerController; // the AMC is how the code interacts with the player
-                //Enable overlay close button right away for Pulse
-                amc.adManagerSettings["showNonLinearCloseButton"] = true;
                 pulseAdManagers[playerId] = this;
 
                 // Add any player event listeners now
@@ -474,7 +472,7 @@
 
             //Called when the overlay is displayed
             function onOverlayShown(){
-                if(currentOverlayAd){
+                if(currentOverlayAd) {
                     overlayTimeLeftMillis = currentOverlayAd.ad.getDuration() * 1000;
                     adPlayer.overlayAdShown(currentOverlayAd.ad);
                     startOverlayCountdown();
@@ -512,8 +510,9 @@
                     }
 
                     amc.sendURLToLoadAndPlayNonLinearAd(v4ad.ad, v4ad.id, v4ad.ad.getResourceURL());
+                    amc.showNonlinearAdCloseButton();
 
-                    //Assume the ad was loaded
+                    // Assume the ad was loaded
                     if(!contentPaused){
                         onOverlayShown();
                     }
@@ -719,16 +718,12 @@
              * @param pulsePauseAd
              */
             this.showPauseAd = function (pulsePauseAd) {
-                //console.error("Showing pause ad", pulsePauseAd);
-                //this._currentPauseAd = pulsePauseAd;
-                //
-                //amc.forceAdToPlay(this.name, pulsePauseAd, amc.ADTYPE.NONLINEAR_OVERLAY, [pulsePauseAd.getResourceURL()]);
+                /* not implemented */
             };
 
             //This method is called by the V4 AMF
             this.showOverlay = function () {
-                if (currentOverlayAd){
-                    amc.sendURLToLoadAndPlayNonLinearAd(currentOverlayAd.ad, currentOverlayAd.id, currentOverlayAd.ad.getResourceURL());
+                if (currentOverlayAd) {
                     startOverlayCountdown();
                 }
             };
@@ -817,17 +812,17 @@
                             }, this.sharedVideoElement);
 
                         //We register all the event listeners we will need
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.AD_BREAK_FINISHED, _.bind(_onAdBreakFinished,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.AD_BREAK_STARTED, _.bind(_onAdBreakStarted,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_FINISHED, _.bind(_onAdFinished,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_SKIPPED, _.bind(_onAdSkipped,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_STARTED, _.bind(_onAdStarted,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_PROGRESS, _.bind(_onAdTimeUpdate,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.AD_CLICKED, _.bind(_onAdClicked,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_PAUSED, _.bind(_onAdPaused,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_PLAYING, _.bind(_onAdPlaying,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.SESSION_STARTED, _.bind(_onSessionStarted,this));
-                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.OVERLAY_AD_SHOWN, _.bind(_onOverlayShown,this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.AD_BREAK_FINISHED, _.bind(_onAdBreakFinished, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.AD_BREAK_STARTED, _.bind(_onAdBreakStarted, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_FINISHED, _.bind(_onAdFinished, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_SKIPPED, _.bind(_onAdSkipped, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_STARTED, _.bind(_onAdStarted, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_PROGRESS, _.bind(_onAdTimeUpdate, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.AD_CLICKED, _.bind(_onAdClicked, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_PAUSED, _.bind(_onAdPaused, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.LINEAR_AD_PLAYING, _.bind(_onAdPlaying, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.SESSION_STARTED, _.bind(_onSessionStarted, this));
+                        adPlayer.addEventListener(OO.Pulse.AdPlayer.Events.OVERLAY_AD_SHOWN, _.bind(_onOverlayShown, this));
 
                         if(pluginCallbacks && pluginCallbacks.onAdPlayerCreated) {
                             pluginCallbacks.onAdPlayerCreated(adPlayer);
@@ -928,9 +923,9 @@
                     -1, isFullscreen);
             };
 
-            //Will be used when overlay events are added
-            var _onOverlayShown = function (event, metadata) {
-                //amc.sendURLToLoadAndPlayNonLinearAd("test", "id",metadata.ad.getResourceURL());
+            var _onOverlayShown = function(event, metadata) {
+                /* Impression is tracked by the SDK before this 
+                   handler is triggered, so nothing needs to be done here */
             };
         };
         return new PulseAdManager();

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -59,9 +59,6 @@
                 amc = adManagerController; // the AMC is how the code interacts with the player
                 //Enable overlay close button right away for Pulse
                 amc.adManagerSettings["showNonLinearCloseButton"] = true;
-
-
-
                 pulseAdManagers[playerId] = this;
 
                 // Add any player event listeners now
@@ -78,7 +75,7 @@
 
             this.getAdPlayer = function() {
                 return adPlayer;
-            }
+            };
 
             /**
              * Called by the AMF when the UI is ready.
@@ -103,7 +100,7 @@
                     (amc.ui.ooyalaVideoElement[0].className === "video")) {
                     this.sharedVideoElement = this.ui.ooyalaVideoElement[0];
                 }
-            }
+            };
 
 
             function mergeCommaSeparatedListsBase(a, b){
@@ -119,7 +116,7 @@
             }
 
             function removeUndefinedElements(args){
-                var retArray = []
+                var retArray = [];
                 for(var i = 0, n = args.length; i < n; i++){
                     if(args[i]){
                         retArray.push(args[i]);
@@ -614,7 +611,7 @@
             this.registerVideoControllerWrapper = function(videoPlugin)
             {
                 this.videoControllerWrapper = videoPlugin;
-            }
+            };
 
             var _onContentChanged = function() {
                 //Not needed rn
@@ -737,7 +734,6 @@
                 if(adPlayer){
                     adPlayer.adClickThroughOpened();
                 }
-
             };
 
             var playPlaceholder = _.bind(function () {


### PR DESCRIPTION
This pull request is the first step in supporting overlays for V4 + Pulse. Its current limitation is that it will track impression as soon as we tell the player to show the overlay image. We'll add support for error tracking in a later release. This code also contains some commented code for the upcoming support of pause ads as well.