### PR TITLE
Ad error fix

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1277,7 +1277,7 @@ require("../html5-common/js/utils/utils.js");
         var eventType = google.ima.AdEvent.Type;
         // Add listeners to the required events.
         _IMAAdsManager.addEventListener(eventType.CLICK, _IMA_SDK_onAdClicked, false, this);
-        _IMAAdsManager.addEventListener(eventType.AD_ERROR, _onImaAdError, false, this);
+        _IMAAdsManager.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, _onImaAdError, false, this);
         _IMAAdsManager.addEventListener(eventType.CONTENT_PAUSE_REQUESTED, _IMA_SDK_pauseMainContent, false, this);
         _IMAAdsManager.addEventListener(eventType.CONTENT_RESUME_REQUESTED, _IMA_SDK_resumeMainContent, false, this);
 

--- a/test/unit-test-helpers/mock_ima.js
+++ b/test/unit-test-helpers/mock_ima.js
@@ -182,7 +182,6 @@ google =
         USER_CLOSE : "userClose",
         DURATION_CHANGE : "durationChange",
         CLICK : "click",
-        AD_ERROR : "adError",
         CONTENT_PAUSE_REQUESTED : "contentPauseRequested",
         CONTENT_RESUME_REQUESTED : "contentResumeRequested"
       }

--- a/test/unit-test-helpers/mock_ima.js
+++ b/test/unit-test-helpers/mock_ima.js
@@ -74,7 +74,9 @@ google =
     },
     AdErrorEvent :
     {
-      Type : {}
+      Type : {
+        AD_ERROR : "adError"
+      }
     },
     AdsLoader : function(container)
     {

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -576,7 +576,7 @@ describe('ad_manager_ima', function()
     });
     var am = google.ima.adManagerInstance;
     am.publishEvent(google.ima.AdEvent.Type.STARTED);
-    am.publishEvent(google.ima.AdEvent.Type.AD_ERROR);
+    am.publishEvent(google.ima.AdErrorEvent.Type.AD_ERROR);
     expect(linearAdEndedNotified).to.be(true);
     expect(podEndedNotified).to.be(true);
     expect(doneControllingAdsNotified).to.be(true);


### PR DESCRIPTION
-found during testing of PLAYER-397 for Chromepocalypse
-fixes an issue where ad errors from the AdsManager object were not being handled properly