### PR TITLE
[PLAYER-319] - (IMA) Added support for non-linear ads when using Ad Rules or VMAP

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1095,11 +1095,8 @@ require("../html5-common/js/utils/utils.js");
         _IMA_SDK_destroyAdsLoader();
         _IMAAdsLoader = new google.ima.AdsLoader(_IMAAdDisplayContainer);
         // This will enable notifications whenever ad rules or VMAP ads are scheduled
-        // for playback. Only needed on ad rules mode
-        if (_usingAdRules)
-        {
-          _IMAAdsLoader.getSettings().setAutoPlayAdBreaks(false);
-        }
+        // for playback, it has no effect on regular ads
+        _IMAAdsLoader.getSettings().setAutoPlayAdBreaks(false);
         _IMAAdsLoader.addEventListener(adsManagerEvents.ADS_MANAGER_LOADED, _onAdRequestSuccess, false);
         _IMAAdsLoader.addEventListener(adErrorEvent.AD_ERROR, _onImaAdError, false);
       });

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1202,7 +1202,6 @@ require("../html5-common/js/utils/utils.js");
       {
         if(_usingAdRules)
         {
-          _resetUIContainerStyle();
           //if ads are not ready yet, ima failed to load
           if(!this.adsReady)
           {
@@ -1942,6 +1941,7 @@ require("../html5-common/js/utils/utils.js");
           }
         }
 
+        _resetUIContainerStyle();
         this.currentIMAAd = null;
         this.adPlaybackStarted = false;
       });

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -47,6 +47,7 @@ require("../html5-common/js/utils/utils.js");
       var _linearAdIsPlaying;
       var _timeUpdater = null;
       var _uiContainer = null;
+      var _uiContainerPrevStyle = null;
 
       //Constants
       var DEFAULT_IMA_IFRAME_Z_INDEX = 10004;
@@ -513,7 +514,7 @@ require("../html5-common/js/utils/utils.js");
           _amc.ui.adVideoElement.css(INVISIBLE_CSS);
         }
 
-        if(_usingAdRules)
+        if(_usingAdRules && this.currentAMCAdPod.ad.forced_ad_type !== _amc.ADTYPE.NONLINEAR_OVERLAY)
         {
           _tryStartAd();
         }
@@ -1093,6 +1094,12 @@ require("../html5-common/js/utils/utils.js");
         var adErrorEvent = google.ima.AdErrorEvent.Type;
         _IMA_SDK_destroyAdsLoader();
         _IMAAdsLoader = new google.ima.AdsLoader(_IMAAdDisplayContainer);
+        // This will enable notifications whenever ad rules or VMAP ads are scheduled
+        // for playback. Only needed on ad rules mode
+        if (_usingAdRules)
+        {
+          _IMAAdsLoader.getSettings().setAutoPlayAdBreaks(false);
+        }
         _IMAAdsLoader.addEventListener(adsManagerEvents.ADS_MANAGER_LOADED, _onAdRequestSuccess, false);
         _IMAAdsLoader.addEventListener(adErrorEvent.AD_ERROR, _onImaAdError, false);
       });
@@ -1198,6 +1205,7 @@ require("../html5-common/js/utils/utils.js");
       {
         if(_usingAdRules)
         {
+          _resetUIContainerStyle();
           //if ads are not ready yet, ima failed to load
           if(!this.adsReady)
           {
@@ -1282,6 +1290,7 @@ require("../html5-common/js/utils/utils.js");
         // Add listeners to the required events.
         _IMAAdsManager.addEventListener(eventType.CLICK, _IMA_SDK_onAdClicked, false, this);
         _IMAAdsManager.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, _onImaAdError, false, this);
+        _IMAAdsManager.addEventListener(google.ima.AdEvent.Type.AD_BREAK_READY, _IMA_SDK_onAdBreakReady);
         _IMAAdsManager.addEventListener(eventType.CONTENT_PAUSE_REQUESTED, _IMA_SDK_pauseMainContent, false, this);
         _IMAAdsManager.addEventListener(eventType.CONTENT_RESUME_REQUESTED, _IMA_SDK_resumeMainContent, false, this);
 
@@ -1313,6 +1322,41 @@ require("../html5-common/js/utils/utils.js");
         this.adsReady = true;
         clearTimeout(this.adsRequestTimeoutRef);
         _IMA_SDK_tryInitAdsManager();
+      });
+
+      /**
+       * Fired when IMA SDK has a VMAP or Ad Rules ad that is ready for playback.
+       * @private
+       * @method GoogleIMA#_IMA_SDK_onAdBreakReady
+       * @param adEvent - Event data from IMA SDK.
+       */
+      var _IMA_SDK_onAdBreakReady = privateMember(function(adEvent)
+      {
+        OO.log("GOOGLE_IMA:: Ad Rules ad break ready!", adEvent);
+        // Proceed as usual if we're not using ad rules
+        if (!_usingAdRules)
+        {
+          _IMAAdsManager.start();
+          return;
+        }
+        // Mimic AMC behavior and cancel any existing non-linear ads before playing the next ad.
+        // Note that there is a known issue in the IMA SDK that prevents the COMPLETE
+        // event from being fired when a non-linear ad is removed. This is also a workaround
+        // for that issue.
+        if (this.currentAMCAdPod && this.currentNonLinearIMAAd)
+        {
+          this.cancelAd(this.currentAMCAdPod);
+        }
+        // [PLAYER-319]
+        // IMA will not initialize ad rules overlays unless the ad container is already rendered and
+        // has enough room for the overlay by the time the ad is ready to play. As a workaround, we expand
+        // the ad container and make sure it's rendered, while at the same time hiding it visually.
+        // We store the element's current style in order to restore it afterwards.
+        _uiContainerPrevStyle = _uiContainer.getAttribute("style") || "";
+        _uiContainer.setAttribute("style", "display: block; width: 100%; height: 100%; visibility: hidden; pointer-events: none;");
+        _onSizeChanged();
+        // Resume ads manager operation
+        _IMAAdsManager.start();
       });
 
       /**
@@ -1434,6 +1478,8 @@ require("../html5-common/js/utils/utils.js");
         switch (adEvent.type)
         {
           case eventType.LOADED:
+            _resetUIContainerStyle();
+
             if (ad.isLinear())
             {
               _amc.focusAdVideo();
@@ -1470,6 +1516,13 @@ require("../html5-common/js/utils/utils.js");
               }
               this.videoControllerWrapper.raiseTimeUpdate(this.getCurrentTime(), this.getDuration());
               _startTimeUpdater();
+            }
+            // Non-linear ad rules or VMAP ads will not be started by _tryStartAd()
+            // because there'll be no AMC ad pod. We start them here after the time update event
+            // in order to prevent the progress bar from flashing
+            if (_usingAdRules && !ad.isLinear())
+            {
+              _startNonLinearAdRulesOverlay();
             }
             break;
           case eventType.RESUMED:
@@ -1555,6 +1608,21 @@ require("../html5-common/js/utils/utils.js");
           default:
             break;
         }
+      });
+
+      /**
+       * Will restore the original style of the UI container if one exists.
+       * This is used in a workaround for PLAYER-319.
+       * @private
+       * @method GoogleIMA#_resetUIContainerStyle
+       */
+      var _resetUIContainerStyle = privateMember(function()
+      {
+        if (_uiContainer && typeof _uiContainerPrevStyle !== 'undefined' && _uiContainerPrevStyle !== null)
+        {
+          _uiContainer.setAttribute("style", _uiContainerPrevStyle);
+        }
+        _uiContainerPrevStyle = null;
       });
 
       /**
@@ -1763,6 +1831,24 @@ require("../html5-common/js/utils/utils.js");
       });
 
       /**
+       * Should be called when IMA has shown a non-linear ad rules ad.
+       * Forcing this dummy ad through the AMC queue will raise the necessary
+       * events for Ad Impression and it will also let the skin know that it
+       * needs to show the ads container.
+       * @private
+       * @method GoogleIMA#_startNonLinearAdRulesOverlay
+       */
+      var _startNonLinearAdRulesOverlay = privateMember(function()
+      {
+        var adData = {
+          position_type: AD_RULES_POSITION_TYPE,
+          forced_ad_type: _amc.ADTYPE.NONLINEAR_OVERLAY
+        };
+        _checkCompanionAds(this.currentIMAAd);
+        _amc.forceAdToPlay(this.name, adData, _amc.ADTYPE.NONLINEAR_OVERLAY);
+      });
+
+      /**
        * Stop overlay and prepare the ad manager to be able to request another ad.
        * @private
        * @method GoogleIMA#_stopNonLinearOverlay
@@ -1771,8 +1857,11 @@ require("../html5-common/js/utils/utils.js");
       var _stopNonLinearOverlay = privateMember(function(adId)
       {
         _amc.notifyNonlinearAdEnded(adId);
-        _resetAdsState();
 
+        if (!_usingAdRules)
+        {
+          _resetAdsState();
+        }
       });
 
       /**

--- a/test/unit-test-helpers/mock_amc.js
+++ b/test/unit-test-helpers/mock_amc.js
@@ -92,6 +92,7 @@ fake_amc = function() {
   this.notifyNonlinearAdStarted = function() {};
   this.notifyNonlinearAdEnded = function() {};
   this.hidePlayerUi = function() {};
+  this.focusAdVideo = function() {};
 
   this.adManagerWillControlAds = function() {};
   this.adManagerDoneControllingAds = function() {};

--- a/test/unit-test-helpers/mock_ima.js
+++ b/test/unit-test-helpers/mock_ima.js
@@ -63,7 +63,8 @@ google =
     {
       setPlayerVersion : function() {},
       setPlayerType : function() {},
-      setVpaidMode : function() {}
+      setVpaidMode : function() {},
+      setLocale : function() {}
     },
     AdsManagerLoadedEvent :
     {
@@ -145,6 +146,11 @@ google =
           }
           return google.ima.adManagerInstance;
         }
+      };
+      this.getSettings = function() {
+        return {
+          setAutoPlayAdBreaks: function() {}
+        };
       };
       this.addEventListener = function(event, callback)
       {

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -417,6 +417,55 @@ describe('ad_manager_ima', function()
     expect(notified).to.be(true);
   });
 
+  it('AMC Integration, Ad Rules: Non-linear ad should trigger forceAdToPlay on AMC', function()
+  {
+    var triggered = 0;
+    google.ima.linearAds = false;
+    amc.forceAdToPlay = function(name, metadata, type)
+    {
+      triggered += 1;
+    };
+    initAndPlay(true, vci);
+    var am = google.ima.adManagerInstance;
+    am.publishEvent(google.ima.AdEvent.Type.AD_BREAK_READY);
+    am.publishEvent(google.ima.AdEvent.Type.LOADED);
+    am.publishEvent(google.ima.AdEvent.Type.STARTED);
+    expect(triggered).to.be(1);
+  });
+
+  it('AMC Integration, Ad Rules: Existing non-linear ad should be cancelled when next ad break is ready', function()
+  {
+    google.ima.linearAds = false;
+    amc.playAd = function (ad) {
+      ima.playAd(ad);
+    };
+    amc.forceAdToPlay = function(name, metadata, type) {
+      var adData = {
+        "adManager": name,
+        "adType": type,
+        "ad": metadata,
+        "streams": {},
+        "position": -1 // play immediately
+      };
+      var adPod = new amc.Ad(adData);
+      adPod.id = "adId";
+      amc.timeline.push(adPod);
+      amc.playAd(amc.timeline.shift());
+    };
+    initAndPlay(true, vci);
+    var am = google.ima.adManagerInstance;
+    am.publishEvent(google.ima.AdEvent.Type.AD_BREAK_READY);
+    am.publishEvent(google.ima.AdEvent.Type.LOADED);
+    am.publishEvent(google.ima.AdEvent.Type.STARTED);
+    // These should exist when overlay is being displayed
+    expect(ima.currentAMCAdPod).to.be.ok();
+    expect(ima.currentIMAAd).to.be.ok();
+    am.publishEvent(google.ima.AdEvent.Type.AD_BREAK_READY);
+    // These should be removed when next ad break is ready
+    expect(ima.currentAMCAdPod).to.not.be.ok();
+    expect(ima.currentIMAAd).to.not.be.ok();
+  });
+
   // AMC integration/IMA Event tests
   it('AMC Integration, Non-Ad Rules: amc is notified of a non-linear ad playback', function()
   {


### PR DESCRIPTION
[Ticket](https://jira.corp.ooyala.com/browse/PLAYER-319)

The cause of the issue was similar to what was described on the ticket. The IMA sdk was trying to initialize the overlay, but since the _AdDisplayContainer_ hadn't been set up yet, it bailed out with the following error:

_AdError 501: The overlay ad content could not be displayed since creative dimensions do not align with display area._

With these changes we get notified right before the ad is about to be displayed, so I'm using this cue to initialize the _AdDisplayContainer_. This also hooks up to the AMC so that the `Ad Impression` event gets fired. These changes also fix the exact same issue when using VMAP.

**Known issue:**
The IMA guys confirmed that there is a bug in the SDK that prevents the `COMPLETE` event from getting fired when the overlay is removed. This means that non-linear ads that have a `minSuggestedDuration` will leave behind the transparent ad container when the ad is removed. This will block clicks in a portion of the player.

