### PR TITLE
Pulse plugin: clear _currentAd when ad playback ends

### DIFF
--- a/js/pulse.js
+++ b/js/pulse.js
@@ -997,6 +997,7 @@
             var _onAdFinished = function() {
                 amc.notifyLinearAdEnded(1);
                 enableAdScreenPointerEvents();
+                this._currentAd = null;
             };
 
             var _onAdError = function() {
@@ -1006,6 +1007,7 @@
             var _onAdSkipped = function() {
                 amc.notifyLinearAdEnded(1);
                 enableAdScreenPointerEvents();
+                this._currentAd = null;
             };
 
             var _onAdBreakFinished = function() {


### PR DESCRIPTION
The presence of `_currentAd_` would cause overlay clickthrough to open the URL of the last played linear ad; fixed now