### PR TITLE
Player 1256

### DIFF
--- a/test/unit-test-helpers/mock_amc.js
+++ b/test/unit-test-helpers/mock_amc.js
@@ -103,5 +103,6 @@ fake_amc = function() {
   this.sendURLToLoadAndPlayNonLinearAd = function() {};
   this.showSkipVideoAdButton = function() {};
   this.showCompanion = function() {};
+  this.onSdkAdEvent = function() {};
   this.adManagerSettings = {};
 };

--- a/test/unit-test-helpers/mock_ima.js
+++ b/test/unit-test-helpers/mock_ima.js
@@ -90,6 +90,7 @@ google =
       var callbacks = {};
       var adsManagerLoadedEvent =
       {
+        type : google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED,
         getAdsManager : function()
         {
           if (!google.ima.adManagerInstance)
@@ -135,14 +136,28 @@ google =
               {      //convenience function for unit tests
                 if (typeof amCallbacks[event] === "function" && canPublishEvents)
                 {
-                  amCallbacks[event](
+                  if (event === google.ima.AdErrorEvent.Type.AD_ERROR)
                   {
-                    type : event,
-                    getAd : function()
+                    amCallbacks[event](
                     {
-                      return currentAd;
-                    }
-                  });
+                      type : event,
+                      getError : function()
+                      {
+                        return "Ad Error";
+                      }
+                    });
+                  }
+                  else
+                  {
+                    amCallbacks[event](
+                    {
+                      type : event,
+                      getAd : function()
+                      {
+                        return currentAd;
+                      }
+                    });
+                  }
                 }
               };
               this.getCurrentAd = function()
@@ -189,23 +204,30 @@ google =
     {
       Type :
       {
+        AD_BREAK_READY : "adBreakReady",
+        AD_METADATA : "adMetadata",
         ALL_ADS_COMPLETED : "allAdsCompleted",
+        CLICK : "click",
         COMPLETE : "complete",
-        SKIPPED : "skip",
+        CONTENT_PAUSE_REQUESTED : "contentPauseRequested",
+        CONTENT_RESUME_REQUESTED: "contentResumeRequested",
+        DURATION_CHANGE : "durationChange",
         FIRST_QUARTILE : "firstQuartile",
+        IMPRESSION : "impression",
+        INTERACTION : "interaction",
+        LINEAR_CHANGED : "linearChanged",
         LOADED : "loaded",
+        LOG : "log",
         MIDPOINT : "midpoint",
         PAUSED : "paused",
         RESUMED : "resumed",
+        SKIPPABLE_STATE_CHANGED : "skippableStateChanged",
+        SKIPPED : "skipped",
         STARTED : "started",
         THIRD_QUARTILE : "thirdQuartile",
-        VOLUME_CHANGED : "volumeChanged",
-        VOLUME_MUTED : "volumeMuted",
         USER_CLOSE : "userClose",
-        DURATION_CHANGE : "durationChange",
-        CLICK : "click",
-        CONTENT_PAUSE_REQUESTED : "contentPauseRequested",
-        CONTENT_RESUME_REQUESTED : "contentResumeRequested"
+        VOLUME_CHANGED : "volumeChanged",
+        VOLUME_MUTED : "volumeMuted"
       }
     },
     ViewMode : {},

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -1691,4 +1691,152 @@ describe('ad_manager_ima', function()
     am.publishEvent(google.ima.AdEvent.Type.SKIPPED);
     expect(endedCount).to.be(1);
   });
+
+  it('AMC Integration: IMA plugin calls onSdkAdEvent API after receiving ADS_MANAGER_LOADED event from IMA SDK for a non-ad rules ad', function()
+  {
+    var called = 0;
+    var adPluginName = null;
+    var sdkAdEvent = null;
+    amc.onSdkAdEvent = function(name, adEvent) {
+      called++;
+      adPluginName = name;
+      sdkAdEvent = adEvent;
+    };
+
+    initialize(false);
+    play();
+    ima.playAd(amc.timeline[0]);
+    expect(ima.adsRequested).to.be(true);
+    expect(called).to.be(1);
+    expect(adPluginName).to.be(ima.name);
+    expect(_.isEmpty(sdkAdEvent)).to.be(false);
+  });
+
+  it('AMC Integration: IMA plugin calls onSdkAdEvent API after receiving ADS_MANAGER_LOADED event from IMA SDK for a non-ad rules ad', function()
+  {
+    var called = 0;
+    var adPluginName = null;
+    var sdkAdEventType = null;
+    var sdkAdEvent = null;
+    var sdkAdEventParams = null;
+    amc.onSdkAdEvent = function(name, eventType, event, params) {
+      called++;
+      adPluginName = name;
+      sdkAdEventType = eventType;
+      sdkAdEvent = event;
+      sdkAdEventParams = params;
+    };
+
+    initialize(false);
+    play();
+    ima.playAd(amc.timeline[0]);
+    expect(ima.adsRequested).to.be(true);
+    expect(called).to.be(1);
+    expect(adPluginName).to.be(ima.name);
+    expect(sdkAdEventType).to.be(google.ima.AdsManagerLoadedEvent.Type);
+    expect(sdkAdEvent).to.be(google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED);
+    expect(_.isEmpty(sdkAdEventParams)).to.be(false);
+  });
+
+  it('AMC Integration: IMA plugin calls onSdkAdEvent API after receiving ADS_MANAGER_LOADED event from IMA SDK for an ad rules ad', function()
+  {
+    var called = 0;
+    var adPluginName = null;
+    var sdkAdEventType = null;
+    var sdkAdEvent = null;
+    var sdkAdEventParams = null;
+    amc.onSdkAdEvent = function(name, eventType, event, params) {
+      called++;
+      adPluginName = name;
+      sdkAdEventType = eventType;
+      sdkAdEvent = event;
+      sdkAdEventParams = params;
+    };
+
+    initialize(true);
+    play();
+    expect(ima.adsRequested).to.be(true);
+    expect(called).to.be(1);
+    expect(adPluginName).to.be(ima.name);
+    expect(sdkAdEventType).to.be(google.ima.AdsManagerLoadedEvent.Type);
+    expect(sdkAdEvent).to.be(google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED);
+    expect(_.isEmpty(sdkAdEventParams)).to.be(false);
+  });
+
+  it('AMC Integration: IMA plugin calls onSdkAdEvent API after receiving an ad error from IMA SDK', function()
+  {
+    initAndPlay(true, vci);
+    var adPluginName = null;
+    var sdkAdEventType = null;
+    var sdkAdEvent = null;
+    var sdkAdEventParams = null;
+    amc.onSdkAdEvent = function(name, eventType, event, params) {
+      adPluginName = name;
+      sdkAdEventType = eventType;
+      sdkAdEvent = event;
+      sdkAdEventParams = params;
+    };
+    var am = google.ima.adManagerInstance;
+    am.publishEvent(google.ima.AdEvent.Type.STARTED);
+    am.publishEvent(google.ima.AdErrorEvent.Type.AD_ERROR);
+    expect(adPluginName).to.be(ima.name);
+    expect(sdkAdEventType).to.be(google.ima.AdErrorEvent.Type);
+    expect(sdkAdEvent).to.be(google.ima.AdErrorEvent.Type.AD_ERROR);
+    expect(_.isEmpty(sdkAdEventParams)).to.be(false);
+  });
+
+  it('AMC Integration: IMA plugin calls onSdkAdEvent API after receiving an ad event from IMA SDK', function()
+  {
+    initAndPlay(true, vci);
+    var am = google.ima.adManagerInstance;
+    var eventType = google.ima.AdEvent.Type;
+    var imaAdEvents = [
+      eventType.CONTENT_PAUSE_REQUESTED,
+      eventType.AD_BREAK_READY,
+      eventType.AD_METADATA,
+      eventType.LOADED,
+      eventType.STARTED,  //started required for some of the following events
+      eventType.CLICK,
+      eventType.DURATION_CHANGE,
+      eventType.FIRST_QUARTILE,
+      eventType.IMPRESSION,
+      eventType.INTERACTION,
+      eventType.LINEAR_CHANGED,
+      eventType.LOG,
+      eventType.MIDPOINT,
+      eventType.PAUSED,
+      eventType.RESUMED,
+      eventType.SKIPPABLE_STATE_CHANGED,
+      eventType.THIRD_QUARTILE,
+      eventType.VOLUME_CHANGED,
+      eventType.VOLUME_MUTED,
+      eventType.USER_CLOSE,
+      eventType.STARTED,  //need started event for SKIPPED
+      eventType.SKIPPED,
+      eventType.STARTED,  //need started event for COMPLETE
+      eventType.COMPLETE,
+      eventType.STARTED,  //need started event for ALL_ADS_COMPLETED
+      eventType.ALL_ADS_COMPLETED,
+      eventType.CONTENT_RESUME_REQUESTED
+    ];
+    var adPluginName = null;
+    var sdkAdEventType = null;
+    var sdkAdEvent = null;
+    var sdkAdEventParams = null;
+    amc.onSdkAdEvent = function(name, eventType, event, params) {
+      adPluginName = name;
+      sdkAdEventType = eventType;
+      sdkAdEvent = event;
+      sdkAdEventParams = params;
+    };
+    var event;
+    for(var i in imaAdEvents) {
+      event = imaAdEvents[i];
+      am.publishEvent(event);
+      expect(adPluginName).to.be(ima.name);
+      expect(sdkAdEventType).to.be(eventType);
+      expect(sdkAdEvent).to.be(event);
+      expect(_.isEmpty(sdkAdEventParams)).to.be(false);
+    }
+  });
 });


### PR DESCRIPTION
-removed separate AD_BREAK_READY, CLICK, CONTENT_PAUSE_REQUESTED, and CONTENT_RESUME_REQUESTED listeners. These are handled in the _IMA_SDK_onAdEvent function now
-integrated with the new AMC onSdkAdEvent API