### PR TITLE
[pulse-ready-fix]

### DIFF
--- a/js/ad_manager_template.js
+++ b/js/ad_manager_template.js
@@ -74,6 +74,9 @@ OO.Ads.manager(function(_, $) {
      */
     this.loadMetadata = function(adManagerMetadata, backlotBaseMetadata, movieMetadata) {
       this.ready = true;
+      //Call the onAdManagerReady API after setting this.ready to true
+      //to notify the Ad Manager Controller that this ad plugin is ready
+      amc.onAdManagerReady();
     };
 
     /**

--- a/js/pulse.js
+++ b/js/pulse.js
@@ -359,10 +359,14 @@
 
                 if(!this._pulseHost) {
                     log('No Pulse hostname found in plugin parameters or media metadata; will not attempt to show Pulse ads');
+                    this.ready = true;
+                    amc.onAdManagerReady();
                     return;
                 }
 
                 this.ready = true;
+                amc.onAdManagerReady();
+
                 this._deviceContainer = adManagerMetadata.pulse_device_container;
                 if (adManagerMetadata.pulse_persistent_id) {
                   this._persistentId = adManagerMetadata.pulse_persistent_id;


### PR DESCRIPTION
Note that this is a suggestion and is not fully tested. Please feel free to make any changes necessary.

-fixed an issue where if there is no _pulseHost, the AMC has to wait until the Pulse ad plugin times out before notifying of playback ready