### PR TITLE
Player 1394b

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -1145,13 +1145,31 @@ OO.Ads.manager(function(_, $) {
      */
     var _getLinearClickTrackingUrls = function(amcAd) {
       var vastAdObject = _getVastAdObject(amcAd);
-      var linearClickTrackingUrls = null;
-      if (vastAdObject &&
-          vastAdObject.linear &&
-          vastAdObject.linear.clickTracking &&
-          vastAdObject.linear.clickTracking.length > 0) {
-        linearClickTrackingUrls = vastAdObject.linear.clickTracking;
+      var linearClickTrackingUrls = [];
+      if (vastAdObject){
+        if (vastAdObject.linear &&
+            vastAdObject.linear.clickTracking &&
+            vastAdObject.linear.clickTracking.length > 0) {
+          linearClickTrackingUrls = linearClickTrackingUrls.concat(vastAdObject.linear.clickTracking);
+        }
+
+        if (vastAdObject.linear &&
+          vastAdObject.linear.clickThrough &&
+          vastAdObject.linear.clickThrough.length > 0) {
+          linearClickTrackingUrls = linearClickTrackingUrls.concat(vastAdObject.linear.clickThrough);
+        }
+
+        if (vastAdObject.linear &&
+          vastAdObject.linear.customClick &&
+          vastAdObject.linear.customClick.length > 0) {
+          linearClickTrackingUrls = linearClickTrackingUrls.concat(vastAdObject.linear.customClick);
+        }
       }
+
+      if (_.isEmpty(linearClickTrackingUrls)) {
+        linearClickTrackingUrls = null;
+      }
+
       return linearClickTrackingUrls;
     };
 
@@ -1801,7 +1819,7 @@ OO.Ads.manager(function(_, $) {
      */
     this.trackError = function(code, currentAdId) {
       if (currentAdId && currentAdId in this.adTrackingInfo) {
-        this.pingURLs(this.adTrackingInfo[currentAdId].errorURLs);
+        this.pingURLs(code, this.adTrackingInfo[currentAdId].errorURLs);
         var parentId = this.adTrackingInfo[currentAdId].wrapperParentId;
 
         // ping parent wrapper's error urls too if ad had parent
@@ -1831,8 +1849,8 @@ OO.Ads.manager(function(_, $) {
      * @param {string[]} urls URLs to ping
      */
     this.pingURLs = function(code, urls) {
-      _.each(urls, function() {
-        pingURL(code, url);
+      _.each(urls, function(url) {
+        this.pingURL(code, url);
       }, this);
     };
 

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -1072,7 +1072,7 @@ OO.Ads.manager(function(_, $) {
           });
         }
         else {
-          console.log(
+          OO.log(
               "VAST: Tried to ping URLs: [" + trackingEventNames +
               "] but ad object passed in was: " + amcAd
           );
@@ -3028,7 +3028,9 @@ OO.Ads.manager(function(_, $) {
      * @param {string} type Event name to be send
      */
     this.sendVpaidTracking = function(type) {
-      var ad = prevAd ? prevAd : currentAd;
+      //TODO: Why was this fetching previous ad if it existed?
+      //var ad = prevAd ? prevAd : currentAd;
+      var ad = currentAd;
       if (ad && ad.data) {
         var tracking = ad.data.tracking,
             currentEvent;

--- a/test/unit-test-helpers/mock_responses/vast_linear.xml
+++ b/test/unit-test-helpers/mock_responses/vast_linear.xml
@@ -30,6 +30,7 @@
 <VideoClicks>
 <ClickThrough id="GDFP">clickThroughUrl</ClickThrough>
 <ClickTracking id="GDFP">clickTrackingUrl</ClickTracking>
+<CustomClick id="GDFP">customClickUrl</CustomClick>
 </VideoClicks>
 <MediaFiles>
 <MediaFile id="GDFP" delivery="progressive" bitrate="338" width="426" height="240" type="video/x-flv" scalable="false" maintainAspectRatio="false">1.flv</MediaFile>

--- a/test/unit-test-helpers/mock_responses/vast_overlay_missing_url.xml
+++ b/test/unit-test-helpers/mock_responses/vast_overlay_missing_url.xml
@@ -3,6 +3,7 @@
     		<AdSystem version="4.6.0-5">LiveRail</AdSystem>
     		<AdTitle>TV Overlay PNG</AdTitle>
     		<Description>fake test</Description>
+			<Error>errorurl</Error>
     		<Impression id="LR">impressionOverlayUrl</Impression>
             <Impression id="QC">impressionOverlay2Url</Impression>
 			<Impression>impressionOverlay3Url</Impression>

--- a/test/unit-test-helpers/mock_responses/vast_wrapper_1.xml
+++ b/test/unit-test-helpers/mock_responses/vast_wrapper_1.xml
@@ -9,12 +9,16 @@
 		<Creative AdID="wrapper-parent-creative-id-1">
 			<Linear>
 				<TrackingEvents>
-          <Tracking event="start">startWrapper1Url</Tracking>
-          <Tracking event="firstQuartile">firstQuartileWrapper1Url</Tracking>
-          <Tracking event="midpoint">midpointWrapper1Url</Tracking>
-          <Tracking event="thirdQuartile">thirdQuartileWrapper1Url</Tracking>
-          <Tracking event="complete">completeWrapper1Url</Tracking>
+                  <Tracking event="start">startWrapper1Url</Tracking>
+                  <Tracking event="firstQuartile">firstQuartileWrapper1Url</Tracking>
+                  <Tracking event="midpoint">midpointWrapper1Url</Tracking>
+                  <Tracking event="thirdQuartile">thirdQuartileWrapper1Url</Tracking>
+                  <Tracking event="complete">completeWrapper1Url</Tracking>
 				</TrackingEvents>
+                <VideoClicks>
+                    <ClickThrough id="123">clickThroughWrapper1Url</ClickThrough>
+                    <ClickTracking id="123">clickTrackingWrapper1Url</ClickTracking>
+                </VideoClicks>
 			</Linear>
 		</Creative>
 	</Creatives>

--- a/test/unit-test-helpers/mock_responses/vast_wrapper_1.xml
+++ b/test/unit-test-helpers/mock_responses/vast_wrapper_1.xml
@@ -16,8 +16,9 @@
                   <Tracking event="complete">completeWrapper1Url</Tracking>
 				</TrackingEvents>
                 <VideoClicks>
-                    <ClickThrough id="123">clickThroughWrapper1Url</ClickThrough>
-                    <ClickTracking id="123">clickTrackingWrapper1Url</ClickTracking>
+                    <ClickThrough id="GDFP">clickThroughWrapper1Url</ClickThrough>
+                    <ClickTracking id="GDFP">clickTrackingWrapper1Url</ClickTracking>
+                    <CustomClick id="GDFP">customClickWrapper1Url</CustomClick>
                 </VideoClicks>
 			</Linear>
 		</Creative>

--- a/test/unit-test-helpers/mock_responses/vast_wrapper_2.xml
+++ b/test/unit-test-helpers/mock_responses/vast_wrapper_2.xml
@@ -9,12 +9,16 @@
 		<Creative AdID="wrapper-parent-creative-id-2">
 			<Linear>
 				<TrackingEvents>
-          <Tracking event="start">startWrapper2Url</Tracking>
-          <Tracking event="firstQuartile">firstQuartileWrapper2Url</Tracking>
-          <Tracking event="midpoint">midpointWrapper2Url</Tracking>
-          <Tracking event="thirdQuartile">thirdQuartileWrapper2Url</Tracking>
-          <Tracking event="complete">completeWrapper2Url</Tracking>
+                  <Tracking event="start">startWrapper2Url</Tracking>
+                  <Tracking event="firstQuartile">firstQuartileWrapper2Url</Tracking>
+                  <Tracking event="midpoint">midpointWrapper2Url</Tracking>
+                  <Tracking event="thirdQuartile">thirdQuartileWrapper2Url</Tracking>
+                  <Tracking event="complete">completeWrapper2Url</Tracking>
 				</TrackingEvents>
+                <VideoClicks>
+                    <ClickThrough id="123">clickThroughWrapper2Url</ClickThrough>
+                    <ClickTracking id="123">clickTrackingWrapper2Url</ClickTracking>
+                </VideoClicks>
 			</Linear>
 		</Creative>
 	</Creatives>

--- a/test/unit-test-helpers/mock_responses/vast_wrapper_2.xml
+++ b/test/unit-test-helpers/mock_responses/vast_wrapper_2.xml
@@ -16,8 +16,9 @@
                   <Tracking event="complete">completeWrapper2Url</Tracking>
 				</TrackingEvents>
                 <VideoClicks>
-                    <ClickThrough id="123">clickThroughWrapper2Url</ClickThrough>
-                    <ClickTracking id="123">clickTrackingWrapper2Url</ClickTracking>
+                    <ClickThrough id="GDFP">clickThroughWrapper2Url</ClickThrough>
+                    <ClickTracking id="GDFP">clickTrackingWrapper2Url</ClickTracking>
+                    <CustomClick id="GDFP">customClickWrapper2Url</CustomClick>
                 </VideoClicks>
 			</Linear>
 		</Creative>

--- a/test/unit-test-helpers/mock_responses/vpaid_linear.xml
+++ b/test/unit-test-helpers/mock_responses/vpaid_linear.xml
@@ -16,6 +16,10 @@
                         <Tracking event="mute">muteUrl</Tracking>
                       </TrackingEvents>
                       <AdParameters>{"tag" : "ad"}</AdParameters>
+                      <VideoClicks>
+                          <ClickThrough id="123">clickThrough</ClickThrough>
+                          <ClickTracking id="123">clickTracking</ClickTracking>
+                      </VideoClicks>
                       <MediaFiles>
                           <MediaFile delivery="progressive" width="16" height="9" type="application/javascript" apiFramework="VPAID">http://file.js</MediaFile>
                       </MediaFiles>

--- a/test/unit-test-helpers/mock_responses/vpaid_linear.xml
+++ b/test/unit-test-helpers/mock_responses/vpaid_linear.xml
@@ -17,8 +17,9 @@
                       </TrackingEvents>
                       <AdParameters>{"tag" : "ad"}</AdParameters>
                       <VideoClicks>
-                          <ClickThrough id="123">clickThrough</ClickThrough>
-                          <ClickTracking id="123">clickTracking</ClickTracking>
+                          <ClickThrough id="GDFP">clickThrough</ClickThrough>
+                          <ClickTracking id="GDFP">clickTracking</ClickTracking>
+                          <CustomClick id="GDFP">customClick</CustomClick>
                       </VideoClicks>
                       <MediaFiles>
                           <MediaFile delivery="progressive" width="16" height="9" type="application/javascript" apiFramework="VPAID">http://file.js</MediaFile>

--- a/test/unit-test-helpers/mock_vpaid.js
+++ b/test/unit-test-helpers/mock_vpaid.js
@@ -142,8 +142,8 @@ global.vpaidAd = {
           tracking: []
         },
         skipOffset: null,
-        clickTracking: '',
-        clickThrough: '',
+        clickTracking: 'clickTracking',
+        clickThrough: 'clickThrough',
         customClick: ''
       },
       nonLinear: {
@@ -168,7 +168,7 @@ global.vpaidAd = {
       ],
       type: 'linearVideo',
       version: '2.0',
-      videoClickTracking: { clickTracking: '', clickThrough: '', customClick: '' } 
+      videoClickTracking: { clickTracking: 'clickTracking', clickThrough: 'clickThrough', customClick: '' }
     },
     fallbackAd: null,
     positionSeconds: 0,

--- a/test/unit-test-helpers/mock_vpaid.js
+++ b/test/unit-test-helpers/mock_vpaid.js
@@ -144,7 +144,7 @@ global.vpaidAd = {
         skipOffset: null,
         clickTracking: 'clickTracking',
         clickThrough: 'clickThrough',
-        customClick: ''
+        customClick: 'customClick'
       },
       nonLinear: {
         mediaFiles: {
@@ -168,7 +168,7 @@ global.vpaidAd = {
       ],
       type: 'linearVideo',
       version: '2.0',
-      videoClickTracking: { clickTracking: 'clickTracking', clickThrough: 'clickThrough', customClick: '' }
+      videoClickTracking: { clickTracking: 'clickTracking', clickThrough: 'clickThrough', customClick: 'customClick' }
     },
     fallbackAd: null,
     positionSeconds: 0,

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -3142,7 +3142,7 @@ describe('ad_manager_vast', function() {
 
     expect(trackingUrlsPinged.errorWrapper1Url).to.be(1);
 
-    expect(trackingUrlsPinged.errorWrapper2Url).to.be(1);4
+    expect(trackingUrlsPinged.errorWrapper2Url).to.be(1);
   });
 
   it('VAST: Wrapper ad requests should not end ad pod until non-wrapper ad is found', function() {

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -161,15 +161,13 @@ describe('ad_manager_vast', function() {
       }
     };
 
+    var originalTrackError = _.bind(vastAdManager.trackError, vastAdManager);
+
     // mock trackError function to test error tracking
     vastAdManager.trackError = function (code, currentAdId) {
       errorType.push(code);
-      if (currentAdId) {
-        if (currentAdId && currentAdId in this.adTrackingInfo) {
-
-          //directly ping url
-          OO.pixelPing();
-        }
+      if (typeof originalTrackError === "function") {
+        originalTrackError(code, currentAdId);
       }
     };
 
@@ -1490,6 +1488,7 @@ describe('ad_manager_vast', function() {
     vastAdManager.onVastResponse(vast_ad_mid, linear3_0MissingMediaFiles);
     expect(_.contains(errorType, vastAdManager.ERROR_CODES.GENERAL_LINEAR_ADS)).to.be(true);
     expect(pixelPingCalled).to.be(true);
+    expect(trackingUrlsPinged.errorurl).to.be(1);
   });
 
   it('Vast 3.0, Error Reporting: Should report general nonlinear ads error', function(){
@@ -1518,6 +1517,7 @@ describe('ad_manager_vast', function() {
     vastAdManager.onVastResponse(vast_ad_mid, nonLinearXMLMissingURL);
     expect(_.contains(errorType, vastAdManager.ERROR_CODES.GENERAL_NONLINEAR_ADS)).to.be(true);
     expect(pixelPingCalled).to.be(true);
+    expect(trackingUrlsPinged.errorurl).to.be(1);
   });
 
   it('Vast 3.0, VMAP: Should call onVMAPResponse if there is a VMAP XML response', function() {
@@ -3121,6 +3121,23 @@ describe('ad_manager_vast', function() {
 
     expect(trackingUrlsPinged.impressionWrapper1Url).to.be(1);
     expect(trackingUrlsPinged.startWrapper1Url).to.be(1);
+
+    ad.vpaidAd.callEvent('AdClickThru');
+    expect(trackingUrlsPinged.clickTracking).to.be(1);
+    expect(trackingUrlsPinged.clickThrough).to.be(1);
+
+    expect(trackingUrlsPinged.clickTrackingWrapper1Url).to.be(1);
+    expect(trackingUrlsPinged.clickThroughWrapper1Url).to.be(1);
+
+    expect(trackingUrlsPinged.clickTrackingWrapper2Url).to.be(1);
+    expect(trackingUrlsPinged.clickThroughWrapper2Url).to.be(1);
+
+    ad.vpaidAd.callEvent('AdError');
+    expect(trackingUrlsPinged.errorUrl).to.be(1);
+
+    expect(trackingUrlsPinged.errorWrapper1Url).to.be(1);
+
+    expect(trackingUrlsPinged.errorWrapper2Url).to.be(1);4
   });
 
   it('VAST: Wrapper ad requests should not end ad pod until non-wrapper ad is found', function() {

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -2854,6 +2854,8 @@ describe('ad_manager_vast', function() {
     expect(trackingUrlsPinged.midpointUrl).to.be        (1);
     expect(trackingUrlsPinged.thirdQuartileUrl).to.be   (1);
     expect(trackingUrlsPinged.clickTrackingUrl).to.be   (1);
+    expect(trackingUrlsPinged.clickThroughUrl).to.be    (1);
+    expect(trackingUrlsPinged.customClickUrl).to.be     (1);
     expect(trackingUrlsPinged.pauseUrl).to.be           (2);
     expect(trackingUrlsPinged.resumeUrl).to.be          (2);
     expect(trackingUrlsPinged.muteUrl).to.be            (2);
@@ -3125,12 +3127,15 @@ describe('ad_manager_vast', function() {
     ad.vpaidAd.callEvent('AdClickThru');
     expect(trackingUrlsPinged.clickTracking).to.be(1);
     expect(trackingUrlsPinged.clickThrough).to.be(1);
+    expect(trackingUrlsPinged.customClick).to.be(1);
 
     expect(trackingUrlsPinged.clickTrackingWrapper1Url).to.be(1);
     expect(trackingUrlsPinged.clickThroughWrapper1Url).to.be(1);
+    expect(trackingUrlsPinged.customClickWrapper1Url).to.be(1);
 
     expect(trackingUrlsPinged.clickTrackingWrapper2Url).to.be(1);
     expect(trackingUrlsPinged.clickThroughWrapper2Url).to.be(1);
+    expect(trackingUrlsPinged.customClickWrapper2Url).to.be(1);
 
     ad.vpaidAd.callEvent('AdError');
     expect(trackingUrlsPinged.errorUrl).to.be(1);


### PR DESCRIPTION
-fixed an issue where a wrapped VPAID ad would not have its parent wrapper tracking events fired
-fixed an issue where certain VPAID click tracking events were not fired
-fixed an issue where error trackers were not fired
-fixed an issue where clickThrough and customClick trackers were not fired