### PR TITLE
Player 1375

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -151,7 +151,7 @@ require("../html5-common/js/utils/utils.js");
         this.showAdControls = false;
         this.useGoogleAdUI = false;
         this.useGoogleCountdown = false;
-        this.useInsecureVpaidMode = false;
+        this.desiredVpaidMode = null;
         this.imaIframeZIndex = DEFAULT_IMA_IFRAME_Z_INDEX;
 
         //flag to track whether ad rules failed to load
@@ -276,10 +276,10 @@ require("../html5-common/js/utils/utils.js");
           this.useGoogleCountdown = metadata.useGoogleCountdown;
         }
 
-        this.useInsecureVpaidMode = false;
+        this.desiredVpaidMode = null;
         if (metadata.hasOwnProperty("vpaidMode"))
         {
-          this.useInsecureVpaidMode = metadata.vpaidMode === "insecure";
+          this.desiredVpaidMode = metadata.vpaidMode;
         }
 
         this.disableFlashAds = false;
@@ -293,6 +293,30 @@ require("../html5-common/js/utils/utils.js");
         {
           this.imaIframeZIndex = metadata.iframeZIndex;
         }
+
+        //These are required by Google for tracking purposes.
+        google.ima.settings.setPlayerVersion(PLUGIN_VERSION);
+        google.ima.settings.setPlayerType(PLAYER_TYPE);
+        google.ima.settings.setLocale(OO.getLocale());
+
+        var vpaidMode = google.ima.ImaSdkSettings.VpaidMode.INSECURE;
+        if (this.desiredVpaidMode)
+        {
+          switch (this.desiredVpaidMode)
+          {
+            case "secure":
+            case "enabled":
+              vpaidMode = google.ima.ImaSdkSettings.VpaidMode.ENABLED;
+              break;
+            case "disabled":
+              vpaidMode = google.ima.ImaSdkSettings.VpaidMode.DISABLED;
+              break;
+            default:
+              break;
+          }
+        }
+
+        google.ima.settings.setVpaidMode(vpaidMode);
 
         //On second video playthroughs, we will not be initializing the ad manager again.
         //Attempt to create the ad display container here instead of after the sdk has loaded
@@ -1037,19 +1061,6 @@ require("../html5-common/js/utils/utils.js");
           _onImaAdError();
           _amc.unregisterAdManager(this.name);
           return;
-        }
-
-        //These are required by Google for tracking purposes.
-        google.ima.settings.setPlayerVersion(PLUGIN_VERSION);
-        google.ima.settings.setPlayerType(PLAYER_TYPE);
-        google.ima.settings.setLocale(OO.getLocale());
-        if (this.useInsecureVpaidMode)
-        {
-          google.ima.settings.setVpaidMode(google.ima.ImaSdkSettings.VpaidMode.INSECURE);
-        }
-        else
-        {
-          google.ima.settings.setVpaidMode(google.ima.ImaSdkSettings.VpaidMode.ENABLED);
         }
 
         _IMA_SDK_tryInitAdContainer();

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -300,14 +300,13 @@ require("../html5-common/js/utils/utils.js");
         google.ima.settings.setPlayerType(PLAYER_TYPE);
         google.ima.settings.setLocale(OO.getLocale());
 
-        var vpaidMode = google.ima.ImaSdkSettings.VpaidMode.INSECURE;
+        var vpaidMode = google.ima.ImaSdkSettings.VpaidMode.ENABLED;
         if (this.desiredVpaidMode)
         {
           switch (this.desiredVpaidMode)
           {
-            case "secure":
-            case "enabled":
-              vpaidMode = google.ima.ImaSdkSettings.VpaidMode.ENABLED;
+            case "insecure":
+              vpaidMode = google.ima.ImaSdkSettings.VpaidMode.INSECURE;
               break;
             case "disabled":
               vpaidMode = google.ima.ImaSdkSettings.VpaidMode.DISABLED;

--- a/test/unit-test-helpers/mock_ima.js
+++ b/test/unit-test-helpers/mock_ima.js
@@ -6,10 +6,12 @@ google =
                                 //normally a call to requestAds calls its callback immediately in this mock
     adManagerInstance : null,   //for unit test convenience
     adLoaderInstance : null,    //for unit test convenience
+    vpaidMode : null,           //for unit test convenience
     resetDefaultValues : function()
     {
       google.ima.linearAds = true;
       google.ima.delayAdRequest = false;
+      google.ima.vpaidMode = null;
     },
     Ad : function()
     {   //see https://developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.Ad
@@ -67,7 +69,10 @@ google =
     {
       setPlayerVersion : function() {},
       setPlayerType : function() {},
-      setVpaidMode : function() {},
+      setVpaidMode : function(mode)
+      {
+        google.ima.vpaidMode = mode;
+      },
       setLocale : function() {},
       setDisableFlashAds : function() {},
     },
@@ -235,7 +240,9 @@ google =
     {
       VpaidMode :
       {
-        ENABLED : "enabled"
+        ENABLED : "enabled",
+        DISABLED : "disabled",
+        INSECURE : "insecure"
       }
     }
   }

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -1839,4 +1839,74 @@ describe('ad_manager_ima', function()
       expect(_.isEmpty(sdkAdEventParams)).to.be(false);
     }
   });
+
+  it('IMA SDK Integration: Default vpaidMode is set to INSECURE', function()
+  {
+    initialize(false);
+    play();
+    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.INSECURE);
+  });
+
+  it('IMA SDK Integration: Able to set vpaidMode to ENABLED with page level setting \'enabled\'', function()
+  {
+    ima.initialize(amc, playerId);
+    ima.registerUi();
+    expect(ima.ready).to.be(false);
+    var ad =
+    {
+      tag_url : "https://blah",
+      position_type : NON_AD_RULES_POSITION_TYPE
+    };
+    var content =
+    {
+      all_ads : [ad],
+      vpaidMode : "enabled"
+    };
+    ima.loadMetadata(content, {}, {});
+    expect(ima.ready).to.be(true);
+    play();
+    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.ENABLED);
+  });
+
+  it('IMA SDK Integration: Able to set vpaidMode to ENABLED with page level setting \'secure\'', function()
+  {
+    ima.initialize(amc, playerId);
+    ima.registerUi();
+    expect(ima.ready).to.be(false);
+    var ad =
+    {
+      tag_url : "https://blah",
+      position_type : NON_AD_RULES_POSITION_TYPE
+    };
+    var content =
+    {
+      all_ads : [ad],
+      vpaidMode : "secure"
+    };
+    ima.loadMetadata(content, {}, {});
+    expect(ima.ready).to.be(true);
+    play();
+    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.ENABLED);
+  });
+
+  it('IMA SDK Integration: Able to set vpaidMode to DISABLED with page level setting \'disabled\'', function()
+  {
+    ima.initialize(amc, playerId);
+    ima.registerUi();
+    expect(ima.ready).to.be(false);
+    var ad =
+    {
+      tag_url : "https://blah",
+      position_type : NON_AD_RULES_POSITION_TYPE
+    };
+    var content =
+    {
+      all_ads : [ad],
+      vpaidMode : "disabled"
+    };
+    ima.loadMetadata(content, {}, {});
+    expect(ima.ready).to.be(true);
+    play();
+    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.DISABLED);
+  });
 });

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -1820,53 +1820,32 @@ describe('ad_manager_ima', function()
     }
   });
 
-  it('IMA SDK Integration: Default vpaidMode is set to INSECURE', function()
+  it('IMA SDK Integration: Default vpaidMode is set to ENABLED', function()
   {
     initialize(false);
     play();
+    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.ENABLED);
+  });
+
+  it('IMA SDK Integration: Able to set vpaidMode to INSECURE with page level setting \'insecure\'', function()
+  {
+    ima.initialize(amc, playerId);
+    ima.registerUi();
+    expect(ima.ready).to.be(false);
+    var ad =
+    {
+      tag_url : "https://blah",
+      position_type : NON_AD_RULES_POSITION_TYPE
+    };
+    var content =
+    {
+      all_ads : [ad],
+      vpaidMode : "insecure"
+    };
+    ima.loadMetadata(content, {}, {});
+    expect(ima.ready).to.be(true);
+    play();
     expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.INSECURE);
-  });
-
-  it('IMA SDK Integration: Able to set vpaidMode to ENABLED with page level setting \'enabled\'', function()
-  {
-    ima.initialize(amc, playerId);
-    ima.registerUi();
-    expect(ima.ready).to.be(false);
-    var ad =
-    {
-      tag_url : "https://blah",
-      position_type : NON_AD_RULES_POSITION_TYPE
-    };
-    var content =
-    {
-      all_ads : [ad],
-      vpaidMode : "enabled"
-    };
-    ima.loadMetadata(content, {}, {});
-    expect(ima.ready).to.be(true);
-    play();
-    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.ENABLED);
-  });
-
-  it('IMA SDK Integration: Able to set vpaidMode to ENABLED with page level setting \'secure\'', function()
-  {
-    ima.initialize(amc, playerId);
-    ima.registerUi();
-    expect(ima.ready).to.be(false);
-    var ad =
-    {
-      tag_url : "https://blah",
-      position_type : NON_AD_RULES_POSITION_TYPE
-    };
-    var content =
-    {
-      all_ads : [ad],
-      vpaidMode : "secure"
-    };
-    ima.loadMetadata(content, {}, {});
-    expect(ima.ready).to.be(true);
-    play();
-    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.ENABLED);
   });
 
   it('IMA SDK Integration: Able to set vpaidMode to DISABLED with page level setting \'disabled\'', function()
@@ -1888,6 +1867,27 @@ describe('ad_manager_ima', function()
     expect(ima.ready).to.be(true);
     play();
     expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.DISABLED);
+  });
+
+  it('IMA SDK Integration: vpaidMode is set to ENABLED with invalid vpaidMode page level setting', function()
+  {
+    ima.initialize(amc, playerId);
+    ima.registerUi();
+    expect(ima.ready).to.be(false);
+    var ad =
+    {
+      tag_url : "https://blah",
+      position_type : NON_AD_RULES_POSITION_TYPE
+    };
+    var content =
+    {
+      all_ads : [ad],
+      vpaidMode : ""
+    };
+    ima.loadMetadata(content, {}, {});
+    expect(ima.ready).to.be(true);
+    play();
+    expect(google.ima.vpaidMode).to.be(google.ima.ImaSdkSettings.VpaidMode.ENABLED);
   });
 
   it('AMC Integration: IMA plugin provides a default value of 15000 ms for loadVideoTimeout', function()


### PR DESCRIPTION
IMA plugin
-repurposed page level setting “vpaidMode” to allow the user to specify 'insecure' or 'disabled.' Default vpaidMode is 'enabled'
-Moved setting google.ima.settings to loadMetadata so that we can read the metadata/page level settings for the google.ima.settings