### PR TITLE
[player-1264] Changing VAST and IMA to leave calculating ad positions…

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -833,7 +833,7 @@ OO.Ads.manager(function(_, $) {
       var ad = amcAd.ad;
       this.amc.notifyPodStarted(amcAd.id, 1);
 
-      this.currentAdBeingLoaded = ad;
+      this.currentAdBeingLoaded = amcAd;
       this.loadUrl(ad.tag_url);
       loadedAds = true;
       return loadedAds;

--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -909,21 +909,25 @@ OO.Ads.manager(function(_, $) {
             adManager: this.name,
             ad: adMetadata,
             duration: 0,
-            adType: this.amc.ADTYPE.AD_REQUEST
+            adType: this.amc.ADTYPE.AD_REQUEST,
+            mainContentDuration: this.mainContentDuration
           };
 
-          if (adMetadata.position_type == 't') {
+          if (adMetadata.position_type === 't') {
             //Movie metadata uses time, page level metadata uses position
             if (_isValidPosition(adMetadata.time)) {
+
               adData.position = +adMetadata.time / 1000;
             } else if (_isValidPosition(adMetadata.position)) {
               adData.position = +adMetadata.position / 1000;
             }
-          } else if (adMetadata.position_type == 'p') {
+          } else if (adMetadata.position_type === 'p') {
             if (_isValidPosition(adMetadata.position)) {
-              adData.position = +adMetadata.position / 100 * this.mainContentDuration;
+              adData.positionType = adMetadata.position_type;
+              adData.position = +adMetadata.position;
             }
           }
+
           adMetadata.position = adData.position;
 
           //Movie metadata uses url, page level metadata uses tag_url

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -420,7 +420,6 @@ require("../html5-common/js/utils/utils.js");
                   "mainContentDuration": this.mainContentDuration
                 };
 
-                //percentage position types require a different calculation.
                 if (ad.position_type === NON_AD_RULES_PERCENT_POSITION_TYPE)
                 {
                   adData.positionType = NON_AD_RULES_PERCENT_POSITION_TYPE;

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -416,13 +416,15 @@ require("../html5-common/js/utils/utils.js");
                   "adManager": this.name,
                   "ad": ad,
                   "streams": streams,
-                  "adType": _amc.ADTYPE.UNKNOWN_AD_REQUEST
+                  "adType": _amc.ADTYPE.UNKNOWN_AD_REQUEST,
+                  "mainContentDuration": this.mainContentDuration
                 };
 
                 //percentage position types require a different calculation.
-                if (ad.position_type == NON_AD_RULES_PERCENT_POSITION_TYPE)
+                if (ad.position_type === NON_AD_RULES_PERCENT_POSITION_TYPE)
                 {
-                  adData.position = ad.position/100 * this.mainContentDuration;
+                  adData.positionType = NON_AD_RULES_PERCENT_POSITION_TYPE;
+                  adData.position = ad.position;
                 }
 
                 var adToInsert = new _amc.Ad(adData);

--- a/test/unit-tests/vast_test.js
+++ b/test/unit-tests/vast_test.js
@@ -1893,7 +1893,7 @@ describe('ad_manager_vast', function() {
       ]
     }, {}, content);
     amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
-    expect(amc.timeline[0].ad.position).to.be(60);
+    expect(amc.timeline[0].ad.position).to.be(50); //this should be the percentage. The plugin no longer takes care of the calculation
     vastAdManager.playAd(amc.timeline[0]);
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });
@@ -1919,12 +1919,12 @@ describe('ad_manager_vast', function() {
         {
           "tag_url": "http://blahblah",
           "position_type": "p",
-          "position": "50"
+          "position": "70"
         }
       ]
     }, {}, content);
     amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
-    expect(amc.timeline[0].ad.position).to.be(60);
+    expect(amc.timeline[0].ad.position).to.be(70); //this should be the percentage. The plugin no longer takes care of the calculation
     vastAdManager.playAd(amc.timeline[0]);
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });
@@ -1999,8 +1999,8 @@ describe('ad_manager_vast', function() {
     }, {}, content);
     amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
     expect(amc.timeline.length).to.be(2);
-    expect(amc.timeline[0].ad.position).to.be(30);
-    expect(amc.timeline[1].ad.position).to.be(60);
+    expect(amc.timeline[0].ad.position).to.be(25);//this should be the percentage. The plugin no longer takes care of the calculation
+    expect(amc.timeline[1].ad.position).to.be(50);//this should be the percentage. The plugin no longer takes care of the calculation
     vastAdManager.playAd(amc.timeline[0]);
     expect(vastAdManager.vastUrl).to.be("http://blahblah");
   });
@@ -2042,7 +2042,7 @@ describe('ad_manager_vast', function() {
     }, {}, content);
     amc.timeline[0].id = "asdf";//work around because we are using mockAMC and normally it assigns id's
     expect(amc.timeline.length).to.be(3);
-    expect(amc.timeline[0].ad.position).to.be(30);
+    expect(amc.timeline[0].ad.position).to.be(25);//this should be the percentage. The plugin no longer takes care of the calculation
     expect(amc.timeline[1].ad.position).to.be(50);
     //Timeline is not sorted at this point
     expect(amc.timeline[2].ad.position).to.be(0);
@@ -2989,7 +2989,7 @@ describe('ad_manager_vast', function() {
       "html5_ad_server": "http://blah"}, {}, content);
     initialPlay();
     vastAdManager.initialPlay();
-    
+
     // Wrapper ads could be visualized as a tree with parents and children,
     // but in this case, it looks more like a linked list:
     // wrapper-parent-1 -> wrapper-parent-2 -> 6654644 (Inline Linear Ad)
@@ -3001,7 +3001,7 @@ describe('ad_manager_vast', function() {
     vastAdManager.onVastResponse(vast_ad, wrapper1XML);
     vastAdManager.onVastResponse(vast_ad, wrapper2XML, parentDepthOneId);
     vastAdManager.onVastResponse(vast_ad, linearXML, parentDepthTwoId);
-   
+
     var adTrackingInfo = vastAdManager.adTrackingInfo;
 
     // adTrackingInfo should have the three ads parsed
@@ -3044,7 +3044,7 @@ describe('ad_manager_vast', function() {
       "html5_ad_server": "http://blah"}, {}, content);
     initialPlay();
     vastAdManager.initialPlay();
-    
+
     // Wrapper ads could be visualized as a tree with parents and children,
     // but in this case, it looks more like a linked list:
     // wrapper-parent-1 -> wrapper-parent-2 -> 6654644 (Inline Linear Ad)


### PR DESCRIPTION
…, that are percentages, up to the AMC.  They will just pass along the position type and the duration of the content.

This needs to be merged at the same time as https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/307/overview