### PR TITLE
[PBW-6889] Setting VIDEO_STATE_PLAYING when content is resumed

### DIFF
--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -80,6 +80,7 @@ OO.Ads.manager(function(_, $) {
       amc.addPlayerListener(amc.EVENTS.REPLAY_REQUESTED, _.bind(onReplayRequested, this));
       amc.addPlayerListener(amc.EVENTS.PLAY_STARTED, _.bind(onPlay, this));
       amc.addPlayerListener(amc.EVENTS.PAUSE, _.bind(onPause, this));
+      amc.addPlayerListener(amc.EVENTS.RESUME, _.bind(onResume, this));
       amc.addPlayerListener(amc.EVENTS.CONTENT_COMPLETED, _.bind(onContentCompleted, this));
       amc.addPlayerListener(amc.EVENTS.CONTENT_AND_ADS_COMPLETED, _.bind(onAllCompleted, this));
       amc.addPlayerListener(amc.EVENTS.CONTENT_CHANGED, _.bind(onContentChanged, this));
@@ -335,7 +336,7 @@ OO.Ads.manager(function(_, $) {
       if (adRequestTimeout) {
         var error = "Ad Request Timeout already exists - bad state";
         fw_onError(null, error);
-      } 
+      }
       // only set timeout if not in test mode otherwise it will break unit tests
       else if (!this.testMode) {
         adRequestTimeout = _.delay(callback, duration);
@@ -792,7 +793,7 @@ OO.Ads.manager(function(_, $) {
     };
 
     /**
-     * Called when the video is played/resumed.  Sets the video state with Freewheel.
+     * Called when the video is played intially.  Sets the video state with Freewheel.
      * @private
      * @method Freewheel#onPlay
      */
@@ -809,6 +810,16 @@ OO.Ads.manager(function(_, $) {
     var onPause = function() {
       if (!fwContext || !_.isFunction(fwContext.setVideoState)) return;
       fwContext.setVideoState(tv.freewheel.SDK.VIDEO_STATE_PAUSED);
+    };
+
+    /**
+     * Called when the video is resumed after being paused.  Sets the video state with Freewheel.
+     * @private
+     * @method Freewheel#onResume
+     */
+    var onResume = function() {
+      if (!fwContext || !_.isFunction(fwContext.setVideoState)) return;
+      fwContext.setVideoState(tv.freewheel.SDK.VIDEO_STATE_PLAYING);
     };
 
     /**
@@ -951,7 +962,7 @@ OO.Ads.manager(function(_, $) {
     var fw_onSlotEnded = function(event) {
       // Disable controls on the video element.  Freewheel seems to be turning it on
       // TODO: inspect event for playback success or errors
-      
+
       // adVideoElement may be null for overlays
       if (currentPlayingSlot &&
           currentPlayingSlot.getTimePositionClass() !== tv.freewheel.SDK.TIME_POSITION_CLASS_OVERLAY &&
@@ -986,7 +997,7 @@ OO.Ads.manager(function(_, $) {
     }, this);
 
     // Getters
-    
+
     /**
      * Returns whether player is handling click.
      * @public

--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -793,7 +793,7 @@ OO.Ads.manager(function(_, $) {
     };
 
     /**
-     * Called when the video is played intially.  Sets the video state with Freewheel.
+     * Called when the video is played initially.  Sets the video state with Freewheel.
      * @private
      * @method Freewheel#onPlay
      */

--- a/test/unit-test-helpers/mock_fw.js
+++ b/test/unit-test-helpers/mock_fw.js
@@ -48,6 +48,9 @@ tv = {
       TIME_POSITION_CLASS_MIDROLL : "midroll",
       TIME_POSITION_CLASS_POSTROLL : "postroll",
       TIME_POSITION_CLASS_OVERLAY : "overlay",
+      VIDEO_STATE_PLAYING : "playing",
+      VIDEO_STATE_PAUSED : "paused",
+      VIDEO_STATE_STOPPED : "stopped",
       AdManager : function(){
         this.setNetwork = function(){};
         this.setServer = function(){};

--- a/test/unit-tests/freewheel_test.js
+++ b/test/unit-tests/freewheel_test.js
@@ -520,4 +520,41 @@ describe('ad_manager_freewheel', function() {
     fw.playerClicked();
     expect(fw.getHandlingClick()).to.be(true);
   });
+
+  describe('Freewheel Context', function() {
+    var videoState;
+
+    beforeEach(function() {
+      videoState = null;
+      initialize();
+      play();
+      fw.playAd(amc.timeline[0]);
+
+      fwContext.setVideoState = function(state) {
+        videoState = state;
+      };
+    });
+
+    it('should set playing state after initial play', function() {
+      amc.callbacks[amc.EVENTS.PLAY_STARTED]();
+      expect(videoState).to.be(tv.freewheel.SDK.VIDEO_STATE_PLAYING);
+    });
+
+    it('should set paused state when content is paused', function() {
+      amc.callbacks[amc.EVENTS.PAUSE]();
+      expect(videoState).to.be(tv.freewheel.SDK.VIDEO_STATE_PAUSED);
+    });
+
+    it('should set playing state when content is resumed', function() {
+      amc.callbacks[amc.EVENTS.RESUME]();
+      expect(videoState).to.be(tv.freewheel.SDK.VIDEO_STATE_PLAYING);
+    });
+
+    it('should set stopped state when content ends', function() {
+      amc.callbacks[amc.EVENTS.CONTENT_COMPLETED]();
+      expect(videoState).to.be(tv.freewheel.SDK.VIDEO_STATE_STOPPED);
+    });
+
+  });
+
 });


### PR DESCRIPTION
_VIDEO_STATE_PLAYING_ needs to be set when the video resumes after being paused. I added the missing handler for this.