### PR TITLE
Player 1788b

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -668,8 +668,11 @@ require("../html5-common/js/utils/utils.js");
 
       this.setVolume = function(volume)
       {
-        if (_IMAAdsManager && _linearAdIsPlaying)
+        if (_IMAAdsManager)
         {
+          if (typeof this.savedVolume === "number") {
+            this.savedVolume = -1;
+          }
           _IMAAdsManager.setVolume(volume);
         }
         else
@@ -1606,6 +1609,13 @@ require("../html5-common/js/utils/utils.js");
             }
             break;
           case eventType.STARTED:
+            //workaround of an IMA issue where the ad starts paused
+            //on Safari 11 with our muted autoplay flow
+            if (this.videoControllerWrapper.requiresMutedAutoplay()) {
+              _IMAAdsManager.pause();
+              _IMAAdsManager.resume();
+            }
+
             this.adPlaybackStarted = true;
             if(ad.isLinear())
             {

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -670,9 +670,7 @@ require("../html5-common/js/utils/utils.js");
       {
         if (_IMAAdsManager)
         {
-          if (typeof this.savedVolume === "number") {
-            this.savedVolume = -1;
-          }
+          this.savedVolume = -1;
           _IMAAdsManager.setVolume(volume);
         }
         else

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1773,6 +1773,7 @@ require("../html5-common/js/utils/utils.js");
             //calling start() again does not seem to work.
             //Observed on Android Nexus 6P, version 7.1.1
             if (adEvent.type === eventType.VOLUME_MUTED && !this.adPlaybackStarted) {
+              _IMAAdsManager.pause();
               _IMAAdsManager.resume();
             }
             if (this.videoControllerWrapper)

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -1260,9 +1260,9 @@ describe('ad_manager_ima', function()
       });
   });
 
-  it('VTC Integration: Video wrapper setVolume saves volume if ad is not started', function()
+  it('VTC Integration: Video wrapper setVolume saves volume if IMA ad manager is not initialized', function()
   {
-    initAndPlay(true, vci);
+    createVideoWrapper(vci);
     var TEST_VOLUME = 0.5;
     videoWrapper.setVolume(TEST_VOLUME);
     expect(ima.savedVolume).to.be(TEST_VOLUME);
@@ -1279,11 +1279,6 @@ describe('ad_manager_ima', function()
       vol = volume;
     };
     videoWrapper.setVolume(TEST_VOLUME);
-    expect(ima.savedVolume).to.be(TEST_VOLUME);
-    //we tell IMA to start ad
-    videoWrapper.play();
-    //IMA tells us ad is started
-    am.publishEvent(google.ima.AdEvent.Type.STARTED);
     expect(vol).to.be(TEST_VOLUME);
     expect(ima.savedVolume).to.be(-1);
   });


### PR DESCRIPTION
-workaround of an IMA issue where the ad starts paused on Safari 11 with our muted autoplay flow
-modified the setVolume function to set the volume as long as the IMA Ads Manager exists, and will toss the previous saved volume when doing so. This allows us to use this function to prime future ads for unmuted autoplay when called on a user click