### PR TITLE
[player-2348] playerControlsOverAds now overrides the Google IMA show…

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -137,7 +137,6 @@ require("../html5-common/js/utils/utils.js");
         this.currentImpressionTime = 0;
         this.adFinalTagUrl = null;
         this.adPosition = -1;
-        this.showInAdControlBar = false;
         this.adsReady = false;
         this.additionalAdTagParameters = null;
         this.adsRequested = false;
@@ -272,8 +271,14 @@ require("../html5-common/js/utils/utils.js");
           this.additionalAdTagParameters = metadata.additionalAdTagParameters;
         }
 
+        //if playerControlsOverAds is true we can assume the player controls
+        //should be shown. Otherwise use whatever is passed in for showAdControls
         this.showAdControls = false;
-        if (metadata.hasOwnProperty("showAdControls"))
+        if (_amc.pageSettings && _amc.pageSettings.playerControlsOverAds === true)
+        {
+          this.showAdControls = true;
+        }
+        else if (metadata.hasOwnProperty("showAdControls"))
         {
           this.showAdControls = metadata.showAdControls;
         }

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -460,6 +460,62 @@ describe('ad_manager_ima', function()
     expect(notified).to.be(true);
   });
 
+  describe("Show Ad Control tests", function ()
+  {
+    beforeEach(function()
+    {
+      ima.initialize(amc, "blah");
+      amc.adManagerSettings = {};
+    });
+
+    it('Show Ad Controls Override: playerControlsOverAds = true shows ad controls', function()
+    {
+      amc.pageSettings.playerControlsOverAds = true;
+      ima.loadMetadata({}, {}, {});
+      expect(ima.showAdControls).to.be(true);
+    });
+
+    it('Show Ad Controls Override: playerControlsOverAds = true shows ad controls', function()
+    {
+      amc.pageSettings.playerControlsOverAds = true;
+      var metadata = {
+        showAdControls: true
+      }
+      ima.loadMetadata(metadata, {}, {});
+      expect(ima.showAdControls).to.be(true);
+    });
+
+    it('Show Ad Controls Override: playerControlsOverAds = true overrides showAdControls', function()
+    {
+      amc.pageSettings.playerControlsOverAds = true;
+      var metadata = {
+        showAdControls: false
+      }
+      ima.loadMetadata(metadata, {}, {});
+      expect(ima.showAdControls).to.be(true);
+    });
+
+    it('Show Ad Controls Override: playerControlsOverAds = false does not override showAdControls', function()
+    {
+      amc.pageSettings.playerControlsOverAds = false;
+      var metadata = {
+        showAdControls: true
+      }
+      ima.loadMetadata(metadata, {}, {});
+      expect(ima.showAdControls).to.be(true);
+    });
+
+    it('Show Ad Controls Override: playerControlsOverAds = false and showAdControls = false results in no controls', function()
+    {
+      amc.pageSettings.playerControlsOverAds = false;
+      var metadata = {
+        showAdControls: false
+      }
+      ima.loadMetadata(metadata, {}, {});
+      expect(ima.showAdControls).to.be(false);
+    });
+  });
+
   it('AMC Integration, Ad Rules: Non-linear ad should trigger forceAdToPlay on AMC', function()
   {
     var triggered = 0;


### PR DESCRIPTION
…AdControls setting if set to true. So it will force the player controls up. There doesn't seem to be a use case where you would have playerControlsOverAds = true and showAdControls = false