### PR TITLE
[player-2676]

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -854,7 +854,7 @@ require("../html5-common/js/utils/utils.js");
         this.initialPlayRequested = true;
         this.isReplay = false;
         _IMAAdDisplayContainer.initialize();
-        this.capturedUserClick = !wasAutoplayed;
+        this.capturedUserClick = this.capturedUserClick || !wasAutoplayed;
         _IMA_SDK_tryInitAdsManager();
 
         //if we aren't preloading the ads, then it's safe to make the ad request now.

--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -2486,6 +2486,24 @@ describe('ad_manager_ima', function()
     expect(google.ima.adWillPlayMuted).to.be(false);
   });
 
+  it('Muted Autoplay: Ad plugin can play a non-muted ad on second content onwards if we have captured a user click in the first content', function()
+  {
+    ima.requiresMutedAutoplay = function() {
+      return true;
+    };
+    initialize(false);
+    createVideoWrapper(vci);
+    play(false);
+    expect(google.ima.adsManagerStarted).to.be(false);
+    expect(google.ima.adWillPlayMuted).to.be(undefined);
+    ima.playAd(amc.timeline[0]);
+    expect(google.ima.adWillPlayMuted).to.be(false);
+
+    play(true);
+    ima.playAd(amc.timeline[0]);
+    expect(google.ima.adWillPlayMuted).to.be(false);
+  });
+
   describe("Override number of redirects", function() {
     beforeEach(function() {
       ima.maxRedirects = undefined;


### PR DESCRIPTION
-fixed an issue where the IMA ad plugin flag for capturing a user click is reset when a content is autoplayed