### PR TITLE
[player-3192]

### DIFF
--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -936,6 +936,19 @@ OO.Ads.manager(function(_, $) {
      * @param event {object} event The ad impression object indicating which ad ended
      */
     var fw_onAdImpressionEnd = function(event) {
+      //FW has an issue where it resets the html5 video element's volume and muted attributes according to
+      //FW's internal volume/mute state when moving to the next ad in an ad pod (but not the first ad in an ad pod).
+      //This will break playback if muted autoplay is required and FW unmutes the video element. This internal state
+      //is usually set with the setAdVolume API. We currently do not support any video plugin to ad plugin communication,
+      //so the following is a workaround where we get the ad video element's muted state/volume and call setAdVolume
+      //based on these values
+      if (amc && amc.ui && amc.ui.adVideoElement && amc.ui.adVideoElement[0]) {
+        if (amc.ui.adVideoElement[0].muted) {
+          fwContext.setAdVolume(0);
+        } else {
+          fwContext.setAdVolume(amc.ui.adVideoElement[0].volume);
+        }
+      }
       // TODO: inspect event for playback success or errors
       if (_.isFunction(adEndedCallbacks[event.adInstance.getSlot().getCustomId()])) {
         adEndedCallbacks[event.adInstance.getSlot().getCustomId()]();

--- a/test/unit-test-helpers/mock_fw.js
+++ b/test/unit-test-helpers/mock_fw.js
@@ -77,6 +77,7 @@ tv = {
             this.registerVideoDisplayBase = function(){};
             this.setContentVideoElement = function(){};
             this.setVideoState = function(){};
+            this.setAdVolume = function(){};
             this.dispose = function(){};
           };
           return fwContext;

--- a/test/unit-tests/freewheel_test.js
+++ b/test/unit-tests/freewheel_test.js
@@ -626,16 +626,21 @@ describe('ad_manager_freewheel', function() {
   });
 
   describe('Freewheel Context', function() {
-    var videoState;
+    var videoState, volume;
 
     beforeEach(function() {
       videoState = null;
+      volume = null;
       initialize();
       play();
       fw.playAd(amc.timeline[0]);
 
       fwContext.setVideoState = function(state) {
         videoState = state;
+      };
+
+      fwContext.setAdVolume = function(vol) {
+        volume = vol;
       };
     });
 
@@ -659,6 +664,57 @@ describe('ad_manager_freewheel', function() {
       expect(videoState).to.be(tv.freewheel.SDK.VIDEO_STATE_STOPPED);
     });
 
+    it('should set ad volume when ad impression ends', function() {
+      amc.ui = {
+        adVideoElement: [
+          {
+            muted: false,
+            volume: 0.5
+          }
+        ]
+      };
+
+      var adInstance = new AdInstance({
+        name : "blah",
+        width : 300,
+        height : 50,
+        duration : 5
+      });
+
+      expect(volume).to.be(null);
+
+      fwContext.callbacks[tv.freewheel.SDK.EVENT_AD_IMPRESSION_END]({
+        adInstance : adInstance
+      });
+
+      expect(volume).to.be(0.5);
+    });
+
+    it('should mute via setAdVolume when ad impression ends if ad was muted', function() {
+      amc.ui = {
+        adVideoElement: [
+          {
+            muted: true,
+            volume: 0.5
+          }
+        ]
+      };
+
+      var adInstance = new AdInstance({
+        name : "blah",
+        width : 300,
+        height : 50,
+        duration : 5
+      });
+
+      expect(volume).to.be(null);
+
+      fwContext.callbacks[tv.freewheel.SDK.EVENT_AD_IMPRESSION_END]({
+        adInstance : adInstance
+      });
+
+      expect(volume).to.be(0);
+    });
   });
 
 });


### PR DESCRIPTION
-workaround of an issue where FW unmutes after the first ad in an ad pod even though muted autoplay is required