### PR TITLE
[PLAYER-2104] Removing unnecessary references to InitOOJQuery

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -5,7 +5,6 @@
 
 
 require("../html5-common/js/utils/InitModules/InitOO.js");
-require("../html5-common/js/utils/InitModules/InitOOJQuery.js");
 require("../html5-common/js/utils/InitModules/InitOOUnderscore.js");
 require("../html5-common/js/utils/InitModules/InitOOHazmat.js");
 require("../html5-common/js/utils/InitModules/InitOOPlayerParamsDefault.js");

--- a/js/ssai_pulse.js
+++ b/js/ssai_pulse.js
@@ -5,7 +5,6 @@
  */
 
 require("../html5-common/js/utils/InitModules/InitOO.js");
-require("../html5-common/js/utils/InitModules/InitOOJQuery.js");
 require("../html5-common/js/utils/InitModules/InitOOUnderscore.js");
 require("../html5-common/js/utils/InitModules/InitOOHazmat.js");
 require("../html5-common/js/utils/InitModules/InitOOPlayerParamsDefault.js");

--- a/test/test_lib.js
+++ b/test/test_lib.js
@@ -18,6 +18,8 @@ global.window = document.createWindow();
 // by node
 global.window.setTimeout = setTimeout;
 global.navigator = window.navigator;
+global.window.$ = require("jquery");
+OO.$ = global.window.$;
 
 global.expect = require('expect.js');
 
@@ -34,6 +36,5 @@ OO.log = console.log;
 // In a browser environment, all of the properties of "window" (like navigator) are in the global scope:
 OO._.extend(global, window);
 
-require("../html5-common/js/utils/InitModules/InitOOJQuery.js"); //this needs to come after the extend(global, window) line above otherwise $ gets set to undefined.
 require("../html5-common/js/utils/InitModules/InitOOHazmat.js");
 require("../html5-common/js/utils/InitModules/InitOOPlayerParamsDefault.js");


### PR DESCRIPTION
This fixes the issue in which the global jQuery object is either destroyed or modified by the Ad Manager Vast or SSAI Pulse plugins. The `InitOOJQuery` module from `html5-common` is not actually needed because ad plugins get their jQuery reference from the AMC. We will be deprecating `InitOOJQuery` since it causes conflicts with the global jQuery and it's only being used for unit test initialization.