### PR TITLE
[PBW-7274] Fix for event.slotCustomId being null in some cases

### DIFF
--- a/js/freewheel.js
+++ b/js/freewheel.js
@@ -900,21 +900,28 @@ OO.Ads.manager(function(_, $) {
      */
     var fw_onAdImpression = function(event) {
       indexInPod++;
-      if (!event) return;
-      if (_.isFunction(adStartedCallbacks[event.slotCustomId])) {
-        var clickEvents = _.filter(event.adInstance._eventCallbacks,
-                                   function(callback){ return callback._name == "defaultClick" });
+      if (!event || !event.adInstance) {
+        return;
+      }
+      var adInstance = event.adInstance;
+      var adSlot = adInstance.getSlot();
+      var slotCustomId = (adSlot ? adSlot.getCustomId() : '') || event.slotCustomId;
+
+      if (_.isFunction(adStartedCallbacks[slotCustomId])) {
+        var clickEvents = _.filter(adInstance._eventCallbacks, function(callback) {
+          return callback._name === "defaultClick"
+        });
         var hasClickUrl = clickEvents.length > 0;
-        var activeCreativeRendition = event.adInstance.getActiveCreativeRendition();
-        adStartedCallbacks[event.slotCustomId]({
-            name: activeCreativeRendition.getPrimaryCreativeRenditionAsset().getName(),
-            duration: event.adInstance._creative.getDuration(),
-            hasClickUrl: hasClickUrl,
-            indexInPod: indexInPod,
-            skippable: false,
-            width: activeCreativeRendition.getWidth(),
-            height: activeCreativeRendition.getHeight()
-          });
+        var activeCreativeRendition = adInstance.getActiveCreativeRendition();
+        adStartedCallbacks[slotCustomId]({
+          name: activeCreativeRendition.getPrimaryCreativeRenditionAsset().getName(),
+          duration: adInstance._creative.getDuration(),
+          hasClickUrl: hasClickUrl,
+          indexInPod: indexInPod,
+          skippable: false,
+          width: activeCreativeRendition.getWidth(),
+          height: activeCreativeRendition.getHeight()
+        });
       }
 
       /*


### PR DESCRIPTION
[Ticket](https://jira.corp.ooyala.com/browse/PBW-7274)

Simple workaround for an issue in which the `event.slotCustomId` is being passed as `null` in some cases for Ad Impression events. Per Freewheel it seems that `adInstance.getSlot().getCustomId()` is the preferred way to access that value, so we're switching to that and using `event.slotCustomId` as a fallback only.