### PR TITLE
[PLAYER-3912] Notifying non-linear ad end when stream ends with active overlay

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -1494,6 +1494,12 @@ OO.Ads.manager(function(_, $) {
             _skipAd(currentAd);
           }
         }
+        // [PLAYER-3912]
+        // Make sure that NONLINEAR_AD_PLAYED gets fired when a stream ends
+        // with an active overlay, otherwise the skin will keep it for new videos.
+        else if (!ad.isLinear && params.code === this.amc.AD_CANCEL_CODE.STREAM_ENDED) {
+          _endAd(ad, false);
+        }
       }
       else {
         _endAd(ad, false);


### PR DESCRIPTION
The cleanup of the non-linear ad wasn't being performed by the skin when the video was switched while the overlay was active. 