### PR TITLE
Fix/player 3832

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,16 @@ The following example assumes that you hare hosting the html5-skin repo at http:
 </html>
 ```
 
-## Structure and Data Flow
+## Serving from localhost
 
+1. In debugging reason you might need to serve the plugins from localhost
+   ```bash
+   $ gulp webserver watch
+   ```
+2. The plugin files can be accessed then by http://localhost:9003/build/google_ima.js (or any other ad plugin file)
+3. Any changes of the files located under /src path trigger the rebuild process automatically.
+
+We use Mocha as our testing framework: https://mochajs.org/
 
 ## Developer help tool
 You'll need to run a webserver in order to serve the ad_manager_[name].html.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ var gulp = require('gulp'),
     uglify = require('gulp-uglify'),
     shell = require('gulp-shell'),
     rename = require('gulp-rename'),
+    webserver = require('gulp-webserver'),
     _ = require('underscore'),
     listFiles = require('file-lister'),
     exec = require('child_process').exec;
@@ -80,12 +81,24 @@ var getFileNameFromPath = function(path)
   return path.substring(start);
 }
 
+// Run as webserver for debugging purpose
+gulp.task('webserver', 
+  function() {
+    gulp.src('.')
+      .pipe(webserver({
+        livereload: true,
+        directoryListing: true,
+        open: true,
+        port: 9003
+      }));
+  });
+
 // Run tests
 gulp.task('test', shell.task(['make test']));
 
 // Initiate a watch
 gulp.task('watch', function() {
-  gulp.watch(path.scripts, ['browserify']);
+  gulp.watch("js/**/*", ['build']);
 });
 
 // The default task (called when you run `gulp` from cli)

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1069,26 +1069,8 @@ require("../html5-common/js/utils/utils.js");
        * @private
        * @method GoogleIMA#_trySetupAdsRequest
        */
-      const date = Math.round(new Date().getTime());
-      const k = false;
       var _trySetupAdsRequest = privateMember(function()
       {
-        const now = Math.round(new Date().getTime());
-        const diff = now - date;
-        console.log('>>>>>', diff, '>>>>', this.adsRequested,
-          !this.canSetupAdsRequest,
-          !this.adTagUrl,
-          !this.uiRegistered,
-          !_amc.currentEmbedCode,
-          !_IMAAdsLoader,
-          !_checkRequestAdsOnReplay(), '=>', this.adsRequested         ||
-          !this.canSetupAdsRequest   ||
-          !this.adTagUrl             ||
-          !this.uiRegistered         ||
-          !_amc.currentEmbedCode     ||
-          !_IMAAdsLoader             ||
-          !_checkRequestAdsOnReplay());
-
         //need metadata, ima sdk, and ui to be registered before we can request an ad
         if ( this.adsRequested         ||
             !this.canSetupAdsRequest   ||

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1387,8 +1387,7 @@ require("../html5-common/js/utils/utils.js");
       {
         if (adError &&
           adError.type === 'adError' &&
-          adError.h &&
-          adError.h.h === 1009 /*'The VAST response document is empty.'*/ ) {
+          adError.getErrorCode() === 1009 /*'The VAST response document is empty.'*/ ) {
           // Empty response happens when 2 or more ads must be loaded simultaneously after playback seek ahead
           // for 2 or more points of ads. In this case all prev ads loads are cancelled and the only last loaded.
           // The requests for already cancelled ads seems to return empty VAST. Consider this is not an error

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-sourcemaps": "2.6.4",
     "gulp-uglify": "3.0.0",
     "gulp-util": "3.0.8",
+    "gulp-webserver": "0.9.1",
     "hazmat": "*",
     "jquery": "3.3.1",
     "jsdom": "11.11.0",


### PR DESCRIPTION
Added gulp webserver for debugging reasons.
Core fix: ignored 1009 'The VAST response document is empty' Google IMA SDK error returned when request for ads is cancelled.