### PR TITLE
[PBW-7596] prevented setting ads volume to 1 if it is already 1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ var gulp = require('gulp'),
     _ = require('underscore'),
     listFiles = require('file-lister'),
     exec = require('child_process').exec;
+const webserver = require('gulp-webserver');
 var babelify = require('babelify');
 
 var path = {
@@ -85,8 +86,19 @@ gulp.task('test', shell.task(['make test']));
 
 // Initiate a watch
 gulp.task('watch', function() {
-  gulp.watch(path.scripts, ['browserify']);
+  gulp.watch("js/**/*", ['build']);
 });
 
 // The default task (called when you run `gulp` from cli)
-gulp.task('default', ['build']);
+gulp.task('default', ['build', 'webserver', 'watch']);
+
+// Run as webserver for debugging purpose
+gulp.task('webserver', function() {
+  gulp.src('.')
+    .pipe(webserver({
+      livereload: true,
+      directoryListing: true,
+      open: true,
+      port: 9003
+    }));
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,7 +90,7 @@ gulp.task('watch', function() {
 });
 
 // The default task (called when you run `gulp` from cli)
-gulp.task('default', ['build', 'webserver', 'watch']);
+gulp.task('default', ['build']);
 
 // Run as webserver for debugging purpose
 gulp.task('webserver', function() {

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -712,8 +712,10 @@ require("../html5-common/js/utils/utils.js");
           //do not set non-zero volumes if we have not captured the user click
           //since that will cause IMA to error out on platforms where
           //muted autoplay is not supported
-          if (this.capturedUserClick || volume === 0 || !this.requiresMutedAutoplay())
-          {
+          const isVolumeDifferent = _IMAAdsManager.getVolume() !== volume;
+          if (isVolumeDifferent &&
+            (this.capturedUserClick || volume === 0 || !this.requiresMutedAutoplay())
+          ) {
             this.savedVolume = -1;
             _IMAAdsManager.setVolume(volume);
             //workaround of an IMA issue where we don't receive a VOLUME_CHANGED ad event
@@ -1799,6 +1801,7 @@ require("../html5-common/js/utils/utils.js");
 
               if (this.savedVolume >= 0)
               {
+                
                 this.setVolume(this.savedVolume);
                 this.savedVolume = -1;
               }

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1800,8 +1800,7 @@ require("../html5-common/js/utils/utils.js");
               }
 
               if (this.savedVolume >= 0)
-              {
-                
+              { 
                 this.setVolume(this.savedVolume);
                 this.savedVolume = -1;
               }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-sourcemaps": "2.6.4",
     "gulp-uglify": "3.0.0",
     "gulp-util": "3.0.8",
+    "gulp-webserver": "0.9.1",
     "hazmat": "*",
     "jquery": "3.3.1",
     "jsdom": "11.11.0",


### PR DESCRIPTION
Setting the value of ads to 1 when it was already 1 was causing an error from Google IMA SDK. Fixed this.
Also added gulp webserver task for debugging purpose.