### PR TITLE
[PLAYER-5008] set current offset before start

### DIFF
--- a/js/ooyala_ssai.js
+++ b/js/ooyala_ssai.js
@@ -162,6 +162,11 @@ OO.Ads.manager(function(_, $)
       amc.addPlayerListener(amc.EVENTS.AD_VOLUME_CHANGED, _.bind(this.onAdVolumeChanged, this));
       amc.addPlayerListener(amc.EVENTS.MUTE_STATE_CHANGED, _.bind(this.onMuteStateChanged, this));
       amc.addPlayerListener(amc.EVENTS.PLAY_STARTED, _.bind(this.onPlayStarted, this));
+      amc.addPlayerListener(amc.EVENTS.CONTENT_TREE_FETCHED, _.bind(this.onContentTreeFetched, this));
+    };
+
+    this.onContentTreeFetched = function (event, content) {
+      currentOffset = content.duration;
     };
 
     this.onPlayStarted = function () {
@@ -1461,17 +1466,20 @@ OO.Ads.manager(function(_, $)
      */
     var _removeAMCListeners = _.bind(function()
     {
-      if (amc)
-      {
-        amc.removePlayerListener(amc.EVENTS.CONTENT_CHANGED, _.bind(_onContentChanged, this));
-        amc.removePlayerListener(amc.EVENTS.VIDEO_TAG_FOUND, _.bind(this.onVideoTagFound, this));
-        amc.removePlayerListener(amc.EVENTS.CONTENT_URL_CHANGED, _.bind(this.onContentUrlChanged, this));
-        amc.removePlayerListener(amc.EVENTS.FULLSCREEN_CHANGED, _.bind(this.onFullscreenChanged, this));
-        amc.removePlayerListener(amc.EVENTS.AD_VOLUME_CHANGED, _.bind(this.onAdVolumeChanged, this));
-        amc.removePlayerListener(amc.EVENTS.MUTE_STATE_CHANGED, _.bind(this.onMuteStateChanged, this));
-        amc.addPlayerListener(amc.EVENTS.PLAYHEAD_TIME_CHANGED , _.bind(this.onPlayheadTimeChanged, this));
-        amc.addPlayerListener(amc.EVENTS.REPLAY_REQUESTED, _.bind(this.onReplay, this));
+      if (!amc) {
+        return;
       }
+
+      amc.removePlayerListener(amc.EVENTS.CONTENT_CHANGED, _.bind(_onContentChanged, this));
+      amc.removePlayerListener(amc.EVENTS.CONTENT_URL_CHANGED, _.bind(this.onContentUrlChanged, this));
+      amc.removePlayerListener(amc.EVENTS.PLAYHEAD_TIME_CHANGED , _.bind(this.onPlayheadTimeChanged, this));
+      amc.removePlayerListener(amc.EVENTS.VIDEO_TAG_FOUND, _.bind(this.onVideoTagFound, this));
+      amc.removePlayerListener(amc.EVENTS.REPLAY_REQUESTED, _.bind(this.onReplay, this));
+      amc.removePlayerListener(amc.EVENTS.FULLSCREEN_CHANGED, _.bind(this.onFullscreenChanged, this));
+      amc.removePlayerListener(amc.EVENTS.AD_VOLUME_CHANGED, _.bind(this.onAdVolumeChanged, this));
+      amc.removePlayerListener(amc.EVENTS.MUTE_STATE_CHANGED, _.bind(this.onMuteStateChanged, this));
+      amc.removePlayerListener(amc.EVENTS.PLAY_STARTED, _.bind(this.onPlayStarted, this));
+      amc.removePlayerListener(amc.EVENTS.CONTENT_TREE_FETCHED, _.bind(this.onContentTreeFetched, this));
     }, this);
   };
   return new OoyalaSsai();

--- a/test/unit-tests/ooyala_ssai_test.js
+++ b/test/unit-tests/ooyala_ssai_test.js
@@ -163,6 +163,19 @@ describe('ad_manager_ooyala_ssai', function()
       "html5_ad_server": "http://blah"}, {}, content);}).to.not.throwException();
   });
 
+  it('Init: sets currentOffset before video was started', function()
+  {
+    var asset = {
+      duration: 366.61199999999997,
+    };
+
+    OoyalaSsai.initialize(amc);
+    OoyalaSsai.onContentTreeFetched('eventName', asset);
+    expect(OoyalaSsai.getCurrentOffset()).to.equal(366.61199999999997);
+    // we should know video length before sending request for VAST xml for SSAI AD
+    // as it requires current offset from the end
+  });
+
   it('Init: ad manager notifies controller that it is loaded', function()
   {
     var pluginLoaded = false;
@@ -321,7 +334,7 @@ describe('ad_manager_ooyala_ssai', function()
     OoyalaSsai.onAdVolumeChanged("adVolumeChanged", 50);
     expect(trackingUrlsPinged.unmuteUrl).to.be(2);
 
-    // fullscreen events 
+    // fullscreen events
     OoyalaSsai.onFullscreenChanged("fullscreenChanged", true);
     expect(trackingUrlsPinged.fullscreenUrl).to.be(1);
 
@@ -733,7 +746,7 @@ describe('ad_manager_ooyala_ssai', function()
     offset = OoyalaSsai.getCurrentOffset();
     expect(offset).to.be(0);
 
-  }); 
+  });
 
   it('Correct Live offset value should be calculated onPlayheadTimeChanged', function()
   {


### PR DESCRIPTION
SSAI backend requires current offset from the end. When video starts we should already know video duration to set it as offset.
`CONTENT_TREE_FETCHED` fires before start