### PR TITLE
fix/PLAYER-5363 suppressed CORS policy preflight request to get compatible with backend 403 response

### DIFF
--- a/js/ad_manager_vast.js
+++ b/js/ad_manager_vast.js
@@ -1661,6 +1661,7 @@ OO.Ads.manager(() => {
      */
     this.ajax = (url, errorCallback, dataType, loadingAd, wrapperParentId) => {
       fetch(OO.getNormalizedTagUrl(url, this.embedCode), {
+        mode: 'no-cors',
         method: 'get',
         credentials: 'include',
         headers: {


### PR DESCRIPTION
We were doing ajax requests via jQuery before and violated the rule of how CORS should be done (preflight OPTIONS request never issued):
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
After migrating from jQuery.ajax to window.fetch preflight request started working and broke the frontend since backend responds 403 on it. Backend can't fix it. So we suppress OPTIONS request, despite it goes against CORS policy standards. 