### PR TITLE
[PLAYER-5418] - Not able to play VR360 videos on IOS

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -2464,7 +2464,7 @@ require('../html5-common/js/utils/utils.js');
      */
     var applyCssToElement = (css) => {
       if (css && this.isControllingVideo && _ima.sharedVideoElement) {
-        const node = document.querySelector(_ima.sharedVideoElement);
+        const node = document.querySelector(_ima.sharedVideoElement.className, '#' + _ima.sharedVideoElement.id);
         pairs(css).forEach(([key, value]) => {
           node.style[key] = value;
         });


### PR DESCRIPTION
The issue was that ads were not displayed because DOM video element was not found in Safari and Chrome. Solution consist in modifying css selector to make it compatible with Safari.