### PR TITLE
[PLAYER-5471] Fixing ad controls not showing up in FF and Safari

### DIFF
--- a/js/ooyala_ssai.js
+++ b/js/ooyala_ssai.js
@@ -909,8 +909,7 @@ OO.Ads.manager(() => {
         method: 'get',
         credentials: 'omit',
         headers: {
-          pragma: 'no-cache',
-          'cache-control': 'no-cache',
+          'Content-Type': 'application/xml'
         },
       })
         .then(res => res.text())
@@ -934,9 +933,7 @@ OO.Ads.manager(() => {
         method: 'get',
         credentials: 'omit',
         headers: {
-          'Content-Type': 'application/json',
-          'pragma': 'no-cache',
-          'cache-control': 'no-cache'
+          'Content-Type': 'application/json'
         },
       })
         .then(res => res.json())


### PR DESCRIPTION
Fixing PLAER-5471 where ad controls are not showing up in Firefox and Safari for SSAI Ads.

On Firefox and Safari observed the below errors for both metadata and vast requests.Basically after the options call ,the GET call is failing with in browser.Basically even though Options is allowing all the headers with * but somehow FF is not allowing it.I removed cache-control and pragma headers from the request. From the error it is very clear that cache-control header needs to be removed .


Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://ssai.ooyala.com/v1/metadata/dxbzNjZDE6nU5lB0PjWGQmD4Bqj9rcXZ?ssai_guid=be010e7b-a1de-4a2b-8257-f683bab567d1. (Reason: missing token ‘cache-control’ in CORS header ‘Access-Control-Allow-Headers’ from CORS preflight channel)
