### PR TITLE
[PLAYER-5384] OSP bug

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -43,6 +43,7 @@ require('../html5-common/js/utils/utils.js');
       this.sharedVideoElement = null;
       this.initTime = Date.now();
       this.enableIosSkippableAds = false;
+      this.uiContainer = null;
 
       // private member variables of this GoogleIMA object
       let _amc = null;
@@ -526,11 +527,6 @@ require('../html5-common/js/utils/utils.js');
           }
 
           return;
-        }
-
-        // IMA doesn't use the adVideoElement layer so make sure to hide it.
-        if (!_amc.ui.useSingleVideoElement && _amc.ui.adVideoElement) {
-          _amc.ui.adVideoElement.css(INVISIBLE_CSS);
         }
 
         if (_usingAdRules && this.currentAMCAdPod.ad.forced_ad_type !== _amc.ADTYPE.NONLINEAR_OVERLAY) {
@@ -1118,6 +1114,7 @@ require('../html5-common/js/utils/utils.js');
 
             // Prefer to use player skin plugins element to allow for click throughs. Use plugins element if not available
             _uiContainer = _amc.ui.playerSkinPluginsElement ? _amc.ui.playerSkinPluginsElement[0] : _amc.ui.pluginsElement[0];
+            this.uiContainer = _uiContainer;
             // iphone performance is terrible if we don't use the custom playback (i.e. filling in the second param for adDisplayContainer)
             // also doesn't not seem to work nicely with podded ads if you don't use it.
 
@@ -2220,6 +2217,8 @@ require('../html5-common/js/utils/utils.js');
      */
     this.create = (parentContainer, id, ooyalaVideoController, css, playerId) => {
       const googleIMA = registeredGoogleIMAManagers[playerId];
+      const googleIMAWrapperElement = googleIMA.uiContainer.firstElementChild;
+      googleIMAWrapperElement.id = id;
       const wrapper = new GoogleIMAVideoWrapper(googleIMA);
       wrapper.controller = ooyalaVideoController;
       wrapper.subscribeAllEvents();

--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -2217,8 +2217,10 @@ require('../html5-common/js/utils/utils.js');
      */
     this.create = (parentContainer, id, ooyalaVideoController, css, playerId) => {
       const googleIMA = registeredGoogleIMAManagers[playerId];
-      const googleIMAWrapperElement = googleIMA.uiContainer.firstElementChild;
-      googleIMAWrapperElement.id = id;
+      const googleIMAWrapperElement = googleIMA.uiContainer && googleIMA.uiContainer.firstElementChild;
+      if (googleIMAWrapperElement) {
+        googleIMAWrapperElement.id = id;
+      }
       const wrapper = new GoogleIMAVideoWrapper(googleIMA);
       wrapper.controller = ooyalaVideoController;
       wrapper.subscribeAllEvents();


### PR DESCRIPTION
[related core PR](https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/676/overview)

First issue: 

when **video_controller** has created video element it calls *_notifyElementCreated* function
```javascript
_notifyElementCreated() {
  const videoElement = element.parentContainer.find('#' + element.domId);
  mb.publish(OO.EVENTS.VC_VIDEO_ELEMENT_CREATED, {
          'parent': element.parentContainer,
          'videoElement': videoElement,
  });
}
```
in which it tries to find *videoElement* (or video wrapper as it's done with bitmovin) using element.**domId** which was previously passed to adManagerPlugins#create function (but can't do that because there's no element with such id in the DOM)

```javascript
const GoogleIMAVideoFactory = function() {

  this.create = (parentContainer, id, ooyalaVideoController, css, playerId) => {
    const googleIMA = registeredGoogleIMAManagers[playerId];

    // added this lines by analogy with bit_wrapper
    const googleIMAWrapperElement = googleIMA.uiContainer.firstElementChild;
    googleIMAWrapperElement.id = id;
    // so the video_controller could find this wrapper in it's notifyElementCreated() function

    const wrapper = new GoogleIMAVideoWrapper(googleIMA);
    wrapper.controller = ooyalaVideoController;
    wrapper.subscribeAllEvents();
    return wrapper;
  };

}
```
---

Second one:

removed this line from playAd method:
```javascript
this.playAd = () => {
  ...
  // IMA doesn't use the adVideoElement layer so make sure to hide it.
  if (!_amc.ui.useSingleVideoElement && _amc.ui.adVideoElement) {
    _amc.ui.adVideoElement.css(INVISIBLE_CSS);
  }
}
```
* With this lines remained intact ad_plugins#GoogleIMA would hide adVideoElement on every Ad.
* Before it would just hide empty pluginsElement (created by chromelessUi and not used here since the main pluginsElement is the one created by **html5Skin**)

```html
<div class="oo-player-skin-plugins">
  <div id="idPassedToCreateMethod"> <-- googleIMA wrapper, no need to hide it manually
    div>video
    div>video
    iframe
  </div>
</div>
```