### PR TITLE
fix/PLAYER-5619 removed unnecessary run and stop of adTag of 0 duration

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -1159,6 +1159,7 @@ require('../html5-common/js/utils/utils.js');
             if (_usingAdRules
               && !this.hasPreroll
               && this.currentAMCAdPod
+              && this.currentAMCAdPod.duration > 0
               && this.currentAMCAdPod.adType === _amc.ADTYPE.UNKNOWN_AD_REQUEST) {
               _amc.notifyPodStarted(this.currentAMCAdPod.id, 1);
               _endCurrentAd(true);


### PR DESCRIPTION
For unknown reason in the asset with adPod in the middle one more adPod added on 0 position with 0 duration. Down by the code, this qualified as a failure and kills all the ad. I removed this artificial adPod launch (checking for duration greater than zero). Just initializing adManager and waiting for non-zero adPod.