### PR TITLE
PLAYER-5619 google_ima test changed. 0 duration ads shouldn`t play

### DIFF
--- a/test/unit-tests/ima_test.js
+++ b/test/unit-tests/ima_test.js
@@ -356,8 +356,8 @@ describe('ad_manager_ima', function () {
     expect(endNotified).to.be(false);
 
     google.ima.delayedAdRequestCallback();
-    expect(startNotified).to.be(true);
-    expect(endNotified).to.be(true);
+    expect(startNotified).to.be(false);
+    expect(endNotified).to.be(false);
   });
 
   // Non-Ad Rules


### PR DESCRIPTION
I still have no idea, why empty adPod created here https://github.com/ooyala/html5-ad-plugins/blob/master/js/google_ima.js#L1994-L2002
But the truth is 0 duration ad shouldn't play. It's invalid, so I changed tests to the opposite expectations.