### PR TITLE
fix/PLAYER-5670 jQuery dep handled properly

### DIFF
--- a/js/google_ima.js
+++ b/js/google_ima.js
@@ -20,7 +20,7 @@ require('../html5-common/js/utils/constants.js');
 require('../html5-common/js/utils/utils.js');
 
 
-(function () {
+(function ($) {
   const registeredGoogleIMAManagers = {};
 
   OO.Ads.manager(() => {
@@ -2603,4 +2603,4 @@ require('../html5-common/js/utils/utils.js');
   };
 
   OO.Video.plugin(new GoogleIMAVideoFactory());
-}());
+}(OO.$));


### PR DESCRIPTION
Seems like the dep has been removed accidentally while linter was applied. Returned it back.